### PR TITLE
Rename GitHub Actions for monorepo clarity

### DIFF
--- a/.github/workflows/ai-coding-worker-docker-build-push.yml
+++ b/.github/workflows/ai-coding-worker-docker-build-push.yml
@@ -13,7 +13,7 @@ env:
   IMAGE_NAME: ai-coding-worker
 
 jobs:
-  build-and-push:
+  build-and-push-ai-coding-worker:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/collaborative-session-worker-docker-build-push.yml
+++ b/.github/workflows/collaborative-session-worker-docker-build-push.yml
@@ -13,7 +13,7 @@ env:
   IMAGE_NAME: collaborative-session-worker
 
 jobs:
-  build-and-push:
+  build-and-push-collaborative-session-worker:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/storage-worker-docker-build-push.yml
+++ b/.github/workflows/storage-worker-docker-build-push.yml
@@ -13,7 +13,7 @@ env:
   IMAGE_NAME: storage-worker
 
 jobs:
-  build-and-push:
+  build-and-push-storage-worker:
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Updated job names in Docker build-and-push workflows to be more descriptive:
- build-and-push → build-and-push-storage-worker
- build-and-push → build-and-push-collaborative-session-worker
- build-and-push → build-and-push-ai-coding-worker

This makes it easier to identify which service is being built when viewing the GitHub Actions UI.