### PR TITLE
Update runner and provisioner versions

### DIFF
--- a/ai-coding-worker/src/orchestrator.ts
+++ b/ai-coding-worker/src/orchestrator.ts
@@ -290,7 +290,7 @@ export class Orchestrator {
 
       if (shouldAutoCommit) {
         try {
-          const repoPath = path.join(this.tmpDir, `session-${sessionId}`, metadata.github.clonedPath);
+          const repoPath = path.join(this.tmpDir, `session-${sessionId}`, metadata.github!.clonedPath);
           const gitHelper = new GitHelper(repoPath);
 
           // Get current branch name (this is the parent branch)


### PR DESCRIPTION
Add non-null assertion to metadata.github.clonedPath access in auto-commit block. This is safe because the code only enters this block when shouldAutoCommit is true, which is defined as !!metadata.github.