### PR TITLE
Configure GitHub Actions to always run

### DIFF
--- a/.github/workflows/website-deploy-dokploy.yml
+++ b/.github/workflows/website-deploy-dokploy.yml
@@ -2,8 +2,6 @@ name: Website - Deploy to Dokploy
 
 on:
   push:
-    branches-ignore:
-      - main
     paths:
       - "website/**"
       - ".github/workflows/website-deploy-dokploy.yml"


### PR DESCRIPTION
- Removed branches-ignore constraint to enable workflow on all branches
- Website deployments will now trigger on main branch pushes