### PR TITLE
Initialize deployment and clone repository

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -20,14 +20,6 @@ COPY apps ./apps
 # Copy scripts directory for version generation
 COPY scripts ./scripts
 
-# Copy .git directory for version generation
-COPY .git ./.git
-
-# Fetch full git history for accurate version calculation
-# Configure remote and fetch all history and tags
-RUN git remote add origin https://github.com/webedt/website.git 2>/dev/null || true && \
-    git fetch --unshallow --tags 2>/dev/null || git fetch --tags 2>/dev/null || true
-
 # Install all dependencies
 RUN pnpm install --frozen-lockfile
 
@@ -36,8 +28,9 @@ FROM base AS build
 
 WORKDIR /app
 
-# Generate version info from git before building
-RUN node scripts/generate-version.js --update
+# Generate version info from git before building (if git is available)
+# Falls back to using the committed version.ts file if git is not available
+RUN node scripts/generate-version.js --update || echo "Using committed version file"
 
 # Build client (React/Vite app)
 RUN pnpm --filter @webedt/client build


### PR DESCRIPTION
The Dockerfile was failing during deployment because it tried to copy the .git directory, which is not available in the Docker build context when building through Dokploy or other CI/CD platforms.

Changes:
- Removed COPY .git ./.git instruction
- Removed git fetch commands for history/tags
- Made version generation optional with fallback to committed version.ts
- Added graceful fallback message when git is not available

The build now uses the committed version.ts file when git is unavailable, while still supporting dynamic version generation in local development environments where git is present.