### PR TITLE
Fix Docker build by pre-generating version before build

### DIFF
--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -33,6 +33,25 @@ https://github.etdofresh.com/webedt/website/develop/
 - Example: Branch `claude/test-feature` becomes `/webedt/website/claude-test-feature/`
 - The path prefix is stripped by Dokploy before forwarding requests to your app
 
+### Dokploy Build Configuration
+
+**IMPORTANT**: This project requires a pre-build step to generate version information before Docker builds.
+
+**Required Pre-Build Command:**
+```bash
+cd website && ./pre-build.sh
+```
+
+This command must be configured in Dokploy's "Pre Build Command" field. It generates version files from git history that are then included in the Docker build.
+
+**Why This Is Needed:**
+- Version information is calculated from git tags and commit count
+- The `.git` directory is not available in Docker build context
+- Pre-build script generates `package.json` version and `apps/client/src/version.ts` before Docker build
+- These generated files are then copied into the Docker image during the build
+
+**Without the pre-build command, the deployment will fail** because the Docker build will not have access to git history for version generation.
+
 ### Critical Path Requirements for Strip Path
 
 **IMPORTANT**: This project supports both root-based and path-based deployments using runtime base path detection.

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,9 +1,6 @@
 # Multi-stage build for WebEDT monorepo
 FROM node:20-alpine AS base
 
-# Install git (needed for version generation)
-RUN apk add --no-cache git
-
 # Install pnpm
 RUN npm install -g pnpm
 
@@ -23,12 +20,6 @@ RUN echo "Cache bust: 2025-11-23T18:00:00Z commit:d9488ab"
 # Copy apps (this will be rebuilt when cache is invalidated)
 COPY apps ./apps
 
-# Copy scripts directory for version generation
-COPY scripts ./scripts
-
-# Copy .git directory for version generation
-COPY .git ./.git
-
 # Install all dependencies
 RUN pnpm install --frozen-lockfile
 
@@ -37,10 +28,8 @@ FROM base AS build
 
 WORKDIR /app
 
-# Generate version info from git before building
-RUN node scripts/generate-version.js --update
-
 # Build client (React/Vite app)
+# Note: Version files are pre-generated before Docker build
 RUN pnpm --filter @webedt/client build
 
 # Build server (Express API)

--- a/website/apps/client/src/version.ts
+++ b/website/apps/client/src/version.ts
@@ -1,5 +1,5 @@
 // Auto-generated from git tags and commits
 // Run 'pnpm version:generate' to update
-export const VERSION = '0.0.16';
-export const VERSION_TIMESTAMP: string | null = '2025-11-23T17:41:10+00:00';
-export const VERSION_SHA: string | null = 'b5519dfb8761a67efaf977edbe63f7c75df93609';
+export const VERSION = '0.0.22';
+export const VERSION_TIMESTAMP: string | null = '2025-11-23T12:01:49-06:00';
+export const VERSION_SHA: string | null = 'e5610b168a84eab3f02a983587af1fbad2659e62';

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webedt-website",
-  "version": "0.0.16",
+  "version": "0.0.22",
   "description": "AI coding worker website with authentication and GitHub integration",
   "private": true,
   "scripts": {

--- a/website/pre-build.sh
+++ b/website/pre-build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+echo "🔄 Pre-build: Generating version from git..."
+
+# Run version generation script
+node scripts/generate-version.js --update
+
+echo "✅ Pre-build complete: Version files generated"


### PR DESCRIPTION
- Remove .git directory copy from Dockerfile
- Add pre-build.sh script to generate version from git history
- Update CLAUDE.md with Dokploy pre-build configuration instructions
- Remove git installation from Docker image (no longer needed)