### PR TITLE
Coordinate branch naming between website and worker

### DIFF
--- a/ai-coding-worker/src/types.ts
+++ b/ai-coding-worker/src/types.ts
@@ -147,7 +147,8 @@ export interface SessionMetadata {
   updatedAt: string;
   github?: {
     repoUrl: string;
-    branch: string;
+    branch: string; // Parent branch from which the session was created
     clonedPath: string;
+    createdBranch?: string; // Auto-created branch for this session
   };
 }


### PR DESCRIPTION
- Create new branch immediately after cloning repository
- Branch name is generated from user request using Claude Haiku
- Append unique 8-character UUID suffix for uniqueness
- Update auto-commit logic to use pre-created branch
- Send branch_created SSE event with branch name and parent branch
- Store created branch in session metadata
- Website already handles branch_created event (no changes needed)