### PR TITLE
Add display name setting to user profile

### DIFF
--- a/website/apps/client/src/components/Layout.tsx
+++ b/website/apps/client/src/components/Layout.tsx
@@ -75,7 +75,9 @@ export default function Layout() {
   }
 
   // Get user initials for avatar
-  const userInitials = user?.email
+  const userInitials = user?.displayName
+    ? user.displayName.substring(0, 2).toUpperCase()
+    : user?.email
     ? user.email.substring(0, 2).toUpperCase()
     : '??';
 
@@ -256,9 +258,16 @@ export default function Layout() {
 
                 {userMenuOpen && (
                   <div className="absolute right-0 top-full mt-2 w-56 bg-base-100 rounded-lg shadow-xl border border-base-300 py-2 z-50">
-                    {/* User email - non-clickable */}
-                    <div className="px-4 py-2 text-sm text-base-content/70 border-b border-base-300">
-                      📧 {user?.email}
+                    {/* User info - non-clickable */}
+                    <div className="px-4 py-2 text-sm border-b border-base-300">
+                      {user?.displayName ? (
+                        <>
+                          <div className="font-medium text-base-content">{user.displayName}</div>
+                          <div className="text-xs text-base-content/60 mt-0.5">{user.email}</div>
+                        </>
+                      ) : (
+                        <div className="text-base-content/70">📧 {user?.email}</div>
+                      )}
                     </div>
 
                     {/* Store link */}

--- a/website/apps/client/src/lib/api.ts
+++ b/website/apps/client/src/lib/api.ts
@@ -113,6 +113,12 @@ export const userApi = {
       method: 'POST',
       body: { maxDimension },
     }),
+
+  updateDisplayName: (displayName: string) =>
+    fetchApi('/api/user/display-name', {
+      method: 'POST',
+      body: { displayName },
+    }),
 };
 
 // Sessions API

--- a/website/apps/client/src/pages/Chat.tsx
+++ b/website/apps/client/src/pages/Chat.tsx
@@ -997,7 +997,7 @@ export default function Chat() {
                     )}
 
                     <p className="text-xs mt-1 opacity-70">
-                      {message.type === 'user' ? user?.email : message.type === 'assistant' ? 'Claude' : message.type === 'system' ? 'System' : 'Error'} • {new Date(message.timestamp).toLocaleTimeString()}
+                      {message.type === 'user' ? (user?.displayName || user?.email) : message.type === 'assistant' ? 'Claude' : message.type === 'system' ? 'System' : 'Error'} • {new Date(message.timestamp).toLocaleTimeString()}
                     </p>
                     {message.type === 'error' && lastRequest && !isExecuting && (
                       <button

--- a/website/apps/client/src/pages/Settings.tsx
+++ b/website/apps/client/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ export default function Settings() {
   const [claudeAuthJson, setClaudeAuthJson] = useState('');
   const [claudeError, setClaudeError] = useState('');
   const [imageResizeDimension, setImageResizeDimension] = useState(user?.imageResizeMaxDimension || 1024);
+  const [displayName, setDisplayName] = useState(user?.displayName || '');
 
   // Format token expiration time
   const formatTokenExpiration = (expiresAt: number) => {
@@ -55,6 +56,10 @@ export default function Settings() {
     }
   }, [user?.imageResizeMaxDimension]);
 
+  useEffect(() => {
+    setDisplayName(user?.displayName || '');
+  }, [user?.displayName]);
+
   const disconnectGitHub = useMutation({
     mutationFn: githubApi.disconnect,
     onSuccess: async () => {
@@ -100,6 +105,17 @@ export default function Settings() {
     },
   });
 
+  const updateDisplayName = useMutation({
+    mutationFn: userApi.updateDisplayName,
+    onSuccess: async () => {
+      await refreshUserSession();
+      alert('Display name updated successfully');
+    },
+    onError: (error) => {
+      alert(`Failed to update display name: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    },
+  });
+
   const handleClaudeAuthSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setClaudeError('');
@@ -129,6 +145,43 @@ export default function Settings() {
               <p className="text-sm text-base-content/70">
                 <span className="font-medium">User ID:</span> {user?.id}
               </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Display Name */}
+        <div className="card bg-base-100 shadow">
+          <div className="card-body">
+            <h2 className="card-title mb-2">Display Name</h2>
+            <div className="space-y-4">
+              <p className="text-sm text-base-content/70">
+                Set a custom display name that will be shown in your profile and chat messages. If not set, your email will be displayed.
+              </p>
+              <div className="form-control w-full max-w-md">
+                <label className="label">
+                  <span className="label-text">Display Name</span>
+                </label>
+                <input
+                  type="text"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  placeholder="Enter your display name"
+                  className="input input-bordered w-full"
+                  maxLength={100}
+                />
+                <label className="label">
+                  <span className="label-text-alt text-base-content/60">
+                    {displayName.length}/100 characters
+                  </span>
+                </label>
+              </div>
+              <button
+                onClick={() => updateDisplayName.mutate(displayName)}
+                disabled={updateDisplayName.isPending || displayName === (user?.displayName || '')}
+                className="btn btn-primary"
+              >
+                {updateDisplayName.isPending ? 'Saving...' : 'Save Display Name'}
+              </button>
             </div>
           </div>
         </div>

--- a/website/apps/server/src/db/schema.ts
+++ b/website/apps/server/src/db/schema.ts
@@ -3,6 +3,7 @@ import { pgTable, serial, text, timestamp, boolean, integer, json } from 'drizzl
 export const users = pgTable('users', {
   id: text('id').primaryKey(),
   email: text('email').notNull().unique(),
+  displayName: text('display_name'),
   passwordHash: text('password_hash').notNull(),
   githubId: text('github_id').unique(),
   githubAccessToken: text('github_access_token'),

--- a/website/apps/server/src/routes/user.ts
+++ b/website/apps/server/src/routes/user.ts
@@ -94,4 +94,47 @@ router.post('/image-resize-setting', requireAuth, async (req, res) => {
   }
 });
 
+// Update display name
+router.post('/display-name', requireAuth, async (req, res) => {
+  try {
+    const authReq = req as AuthRequest;
+    const { displayName } = req.body;
+
+    // Validate display name (optional field, but if provided should be reasonable)
+    if (displayName !== null && displayName !== undefined && displayName !== '') {
+      if (typeof displayName !== 'string') {
+        res.status(400).json({
+          success: false,
+          error: 'Display name must be a string',
+        });
+        return;
+      }
+
+      if (displayName.length > 100) {
+        res.status(400).json({
+          success: false,
+          error: 'Display name must be 100 characters or less',
+        });
+        return;
+      }
+    }
+
+    // Set to null if empty string
+    const finalDisplayName = displayName === '' ? null : displayName;
+
+    await db
+      .update(users)
+      .set({ displayName: finalDisplayName })
+      .where(eq(users.id, authReq.user!.id));
+
+    res.json({
+      success: true,
+      data: { message: 'Display name updated successfully' },
+    });
+  } catch (error) {
+    console.error('Update display name error:', error);
+    res.status(500).json({ success: false, error: 'Failed to update display name' });
+  }
+});
+
 export default router;

--- a/website/packages/shared/src/types.ts
+++ b/website/packages/shared/src/types.ts
@@ -2,6 +2,7 @@
 export interface User {
   id: number;
   email: string;
+  displayName?: string | null;
   githubId: string | null;
   githubAccessToken: string | null;
   claudeAuth: ClaudeAuth | null;


### PR DESCRIPTION
- Add displayName field to database schema and User type
- Create API endpoint for updating display name
- Add display name input field in Settings page
- Update profile dropdown to show display name with fallback to email
- Update chat messages to show display name instead of email
- Display user initials from display name in avatar