### PR TITLE
Use storage-worker to populate code session page

### DIFF
--- a/website/apps/client/src/lib/api.ts
+++ b/website/apps/client/src/lib/api.ts
@@ -135,6 +135,25 @@ export const sessionsApi = {
     }),
 };
 
+// Storage Worker API
+export const storageWorkerApi = {
+  listSessions: () => fetchApi('/api/storage-worker/sessions'),
+
+  getSession: (sessionId: string) => fetchApi(`/api/storage-worker/sessions/${sessionId}`),
+
+  sessionExists: async (sessionId: string): Promise<boolean> => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/storage-worker/sessions/${sessionId}`, {
+        method: 'HEAD',
+        credentials: 'include',
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  },
+};
+
 // Execute API (SSE)
 export function createExecuteEventSource(data: {
   userRequest: string;


### PR DESCRIPTION
- Add storage-worker API endpoints to api.ts for listing and fetching sessions
- Update Code.tsx to fetch and display sessions from storage-worker
- Add session list view showing session metadata (ID, created date, size)
- Add session detail view with back navigation
- Support both /code and /session/:sessionId/code routes
- Display loading states and error handling for API calls