### PR TITLE
Pass build args to Dokploy via GitHub Actions

### DIFF
--- a/.github/workflows/website-deploy-dokploy.yml
+++ b/.github/workflows/website-deploy-dokploy.yml
@@ -58,6 +58,38 @@ jobs:
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]' | tr '/' '-')
           REPO=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
 
+          # Calculate version from git tags (same logic as generate-version.js)
+          # Format: MAJOR.MINOR.PATCH where PATCH = commits since tag
+          VERSION_INFO=""
+          if DESCRIBE=$(git describe --tags --long --match "v*.*.*" 2>/dev/null); then
+            # Parse git describe output: v1.2.0-5-g1234abc
+            if [[ "$DESCRIBE" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)-g([a-f0-9]+)$ ]]; then
+              MAJOR="${BASH_REMATCH[1]}"
+              MINOR="${BASH_REMATCH[2]}"
+              COMMITS_SINCE="${BASH_REMATCH[4]}"
+              BUILD_VERSION="${MAJOR}.${MINOR}.${COMMITS_SINCE}"
+            fi
+          fi
+
+          # Fallback: count all commits if no tags found
+          if [ -z "$BUILD_VERSION" ]; then
+            COMMIT_COUNT=$(git rev-list --count HEAD 2>/dev/null || echo "0")
+            BUILD_VERSION="0.0.${COMMIT_COUNT}"
+          fi
+
+          # Get commit timestamp and SHA
+          BUILD_TIMESTAMP=$(git log -1 --format=%cI HEAD 2>/dev/null || echo "")
+          BUILD_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+
+          echo "📦 Version Information:"
+          echo "  - Version: ${BUILD_VERSION}"
+          echo "  - Timestamp: ${BUILD_TIMESTAMP}"
+          echo "  - SHA: ${BUILD_SHA}"
+
+          echo "build_version=${BUILD_VERSION}" >> $GITHUB_OUTPUT
+          echo "build_timestamp=${BUILD_TIMESTAMP}" >> $GITHUB_OUTPUT
+          echo "build_sha=${BUILD_SHA}" >> $GITHUB_OUTPUT
+
           # Add project name to distinguish from other monorepo projects
           PROJECT="website"
 
@@ -240,13 +272,18 @@ jobs:
               echo "Response: ${GITHUB_BODY}"
             fi
 
-            # Update deployment settings (replicas, build type)
+            # Update deployment settings (replicas, build type, and build args for version)
+            BUILD_VERSION="${{ steps.metadata.outputs.build_version }}"
+            BUILD_TIMESTAMP="${{ steps.metadata.outputs.build_timestamp }}"
+            BUILD_SHA="${{ steps.metadata.outputs.build_sha }}"
+
             UPDATE_JSON="{
               \"json\": {
                 \"applicationId\": \"${APP_ID}\",
                 \"replicas\": 1,
                 \"buildType\": \"dockerfile\",
-                \"dockerfile\": \"Dockerfile\"
+                \"dockerfile\": \"Dockerfile\",
+                \"buildArgs\": \"BUILD_VERSION=${BUILD_VERSION}\nBUILD_TIMESTAMP=${BUILD_TIMESTAMP}\nBUILD_SHA=${BUILD_SHA}\"
               }
             }"
 
@@ -261,7 +298,8 @@ jobs:
             UPDATE_BODY=$(echo "$UPDATE_RESPONSE" | sed '$d')
 
             if [ "$UPDATE_HTTP_CODE" -ge 200 ] && [ "$UPDATE_HTTP_CODE" -lt 300 ]; then
-              echo "✅ Deployment settings updated successfully (using Dockerfile)"
+              echo "✅ Deployment settings updated successfully (using Dockerfile with build args)"
+              echo "   Build Args: BUILD_VERSION=${BUILD_VERSION}, BUILD_SHA=${BUILD_SHA:0:7}"
             else
               echo "⚠️  Warning: Failed to update deployment settings (HTTP ${UPDATE_HTTP_CODE})"
               echo "Response: ${UPDATE_BODY}"
@@ -339,13 +377,18 @@ jobs:
               exit 1
             fi
 
-            # Update deployment settings (replicas, build type)
+            # Update deployment settings (replicas, build type, and build args for version)
+            BUILD_VERSION="${{ steps.metadata.outputs.build_version }}"
+            BUILD_TIMESTAMP="${{ steps.metadata.outputs.build_timestamp }}"
+            BUILD_SHA="${{ steps.metadata.outputs.build_sha }}"
+
             UPDATE_JSON="{
               \"json\": {
                 \"applicationId\": \"${APP_ID}\",
                 \"replicas\": 1,
                 \"buildType\": \"dockerfile\",
-                \"dockerfile\": \"Dockerfile\"
+                \"dockerfile\": \"Dockerfile\",
+                \"buildArgs\": \"BUILD_VERSION=${BUILD_VERSION}\nBUILD_TIMESTAMP=${BUILD_TIMESTAMP}\nBUILD_SHA=${BUILD_SHA}\"
               }
             }"
 
@@ -360,7 +403,8 @@ jobs:
             UPDATE_BODY=$(echo "$UPDATE_RESPONSE" | sed '$d')
 
             if [ "$UPDATE_HTTP_CODE" -ge 200 ] && [ "$UPDATE_HTTP_CODE" -lt 300 ]; then
-              echo "✅ Deployment settings updated successfully (using Dockerfile)"
+              echo "✅ Deployment settings updated successfully (using Dockerfile with build args)"
+              echo "   Build Args: BUILD_VERSION=${BUILD_VERSION}, BUILD_SHA=${BUILD_SHA:0:7}"
             else
               echo "⚠️  Warning: Failed to update deployment settings (HTTP ${UPDATE_HTTP_CODE})"
               echo "Response: ${UPDATE_BODY}"

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -13,11 +13,7 @@ COPY tsconfig.base.json ./
 # Copy all packages
 COPY packages ./packages
 
-# Cache bust to ensure fresh code is copied
-# Change the date/commit to invalidate cache
-RUN echo "Cache bust: 2025-11-23T18:00:00Z commit:d9488ab"
-
-# Copy apps (this will be rebuilt when cache is invalidated)
+# Copy apps
 COPY apps ./apps
 
 # Install all dependencies
@@ -28,8 +24,22 @@ FROM base AS build
 
 WORKDIR /app
 
-# Note: Version is pre-generated in version.ts before committing
-# Run 'pnpm version:generate' locally to update the version
+# Build args for version info (passed from GitHub Actions via Dokploy)
+ARG BUILD_VERSION=0.0.0
+ARG BUILD_TIMESTAMP=
+ARG BUILD_SHA=
+
+# Generate version.ts from build args
+RUN TIMESTAMP_VALUE="${BUILD_TIMESTAMP:-}" && \
+    SHA_VALUE="${BUILD_SHA:-}" && \
+    if [ -n "$TIMESTAMP_VALUE" ]; then TIMESTAMP_EXPORT="'$TIMESTAMP_VALUE'"; else TIMESTAMP_EXPORT="null"; fi && \
+    if [ -n "$SHA_VALUE" ]; then SHA_EXPORT="'$SHA_VALUE'"; else SHA_EXPORT="null"; fi && \
+    echo "// Auto-generated from build args" > /app/apps/client/src/version.ts && \
+    echo "// Version: ${BUILD_VERSION}" >> /app/apps/client/src/version.ts && \
+    echo "export const VERSION = '${BUILD_VERSION}';" >> /app/apps/client/src/version.ts && \
+    echo "export const VERSION_TIMESTAMP: string | null = $TIMESTAMP_EXPORT;" >> /app/apps/client/src/version.ts && \
+    echo "export const VERSION_SHA: string | null = $SHA_EXPORT;" >> /app/apps/client/src/version.ts && \
+    echo "✓ Generated version.ts: VERSION=${BUILD_VERSION}, SHA=${SHA_VALUE:0:7}"
 
 # Build client (React/Vite app)
 RUN pnpm --filter @webedt/client build


### PR DESCRIPTION
- Calculate version from git tags in GitHub Actions workflow
- Pass BUILD_VERSION, BUILD_TIMESTAMP, BUILD_SHA to Dokploy API
- Update Dockerfile to generate version.ts from build args
- Remove dependency on .git directory in Docker build
- Update documentation to reflect new approach