### PR TITLE
Skip Tagline Truncation On Click

### DIFF
--- a/website/apps/client/src/components/Layout.tsx
+++ b/website/apps/client/src/components/Layout.tsx
@@ -278,8 +278,7 @@ export default function Layout() {
               <div className="hidden md:flex flex-col justify-center py-2">
                 <Link to="/" className="font-semibold text-lg leading-tight">WebEDT</Link>
                 <div
-                  className="text-[10px] text-base-content/30 leading-tight italic max-w-[200px] cursor-pointer hover:text-base-content/40 transition-colors truncate"
-                  title={tagline}
+                  className="text-[10px] text-base-content/30 leading-tight italic cursor-pointer hover:text-base-content/40 transition-colors"
                   onClick={nextTagline}
                 >
                   {tagline}
@@ -303,8 +302,7 @@ export default function Layout() {
               <div className="md:hidden flex flex-col items-center justify-center py-2">
                 <Link to="/" className="font-semibold text-lg leading-tight">WebEDT</Link>
                 <div
-                  className="text-[10px] text-base-content/30 leading-tight italic max-w-[150px] cursor-pointer hover:text-base-content/40 transition-colors truncate"
-                  title={tagline}
+                  className="text-[10px] text-base-content/30 leading-tight italic cursor-pointer hover:text-base-content/40 transition-colors"
                   onClick={nextTagline}
                 >
                   {tagline}


### PR DESCRIPTION
## Summary

Skip Tagline Truncation On Click

## Commits (3)

- `d855997` Replace tagline truncation toggle with cycling through taglines - Unified Worker
- `ab41d8b` Skip useMemo import in Layout component - Unified Worker
- `47ae6e4` Remove tagline truncation and title attribute from Layout - Unified Worker

## Changes

**1** files changed, **13** insertions(+), **12** deletions(-)

### Modified (1)
- website/apps/client/src/components/Layout.tsx

---

*This pull request was generated automatically*