### PR TITLE
Add Time Display to Sessions Data

### DIFF
--- a/website/apps/client/src/pages/Sessions.tsx
+++ b/website/apps/client/src/pages/Sessions.tsx
@@ -484,9 +484,14 @@ export default function Sessions() {
                           {session.status}
                         </span>
                       </div>
-                      <span className="text-sm text-base-content/70">
-                        {new Date(session.createdAt).toLocaleDateString()}
-                      </span>
+                      <div className="text-right">
+                        <div className="text-sm text-base-content/70">
+                          {new Date(session.createdAt).toLocaleDateString()}
+                        </div>
+                        <div className="text-xs text-base-content/60">
+                          {new Date(session.createdAt).toLocaleTimeString()}
+                        </div>
+                      </div>
                       {editingId !== session.id && (
                         <div className="flex items-center space-x-2">
                           <button


### PR DESCRIPTION
## Summary

Add Time Display to Sessions Data

## Commits (1)

- `2eea4d4` Add time display to session creation datetime - Unified Worker

## Changes

**1** files changed, **8** insertions(+), **3** deletions(-)

### Modified (1)
- website/apps/client/src/pages/Sessions.tsx

---

*This pull request was generated automatically*