### PR TITLE
Add Colored Border to Frame Preview

### DIFF
--- a/website/apps/client/src/pages/Preview.tsx
+++ b/website/apps/client/src/pages/Preview.tsx
@@ -81,7 +81,7 @@ function PreviewContent({ previewUrl }: { previewUrl: string | null }) {
           key={iframeKey}
           src={previewUrl}
           title="Repository Preview"
-          className="w-full h-full border-0"
+          className="w-full h-full border-2 border-red-300/50"
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         />


### PR DESCRIPTION
## Summary

Add Colored Border to Frame Preview

## Commits (1)

- `16c0d0b` Add frame preview border styling with red color - Unified Worker

## Changes

**1** files changed, **1** insertions(+), **1** deletions(-)

### Modified (1)
- website/apps/client/src/pages/Preview.tsx

---

*This pull request was generated automatically*