### PR TITLE
Restore Processing Panel on Chat Return

### DIFF
--- a/website/apps/client/src/pages/Chat.tsx
+++ b/website/apps/client/src/pages/Chat.tsx
@@ -921,7 +921,7 @@ export default function Chat() {
     }
   }, [sessionId]);
 
-  const { isConnected } = useEventSource(streamUrl, {
+  useEventSource(streamUrl, {
     method: streamMethod,
     body: streamBody,
     onMessage: (event) => {


### PR DESCRIPTION
## Summary

Restore Processing Panel on Chat Return

## Commits (2)

- `c3f572d` Restore processing panel display when returning to running session - Unified Worker
- `3220bd7` Remove unused isConnected variable from useEventSource - Unified Worker

## Changes

**1** files changed, **8** insertions(+), **13** deletions(-)

### Modified (1)
- website/apps/client/src/pages/Chat.tsx

---

*This pull request was generated automatically*