### PR TITLE
Show Current Branch Instead of Parent

### DIFF
--- a/website/apps/client/src/pages/Chat.tsx
+++ b/website/apps/client/src/pages/Chat.tsx
@@ -1691,13 +1691,11 @@ export default function Chat() {
                       <span className="loading loading-spinner loading-sm text-primary"></span>
                       <div className="flex flex-col">
                         <span className="text-sm text-base-content/70">Processing...</span>
-                        {selectedRepo && (
+                        {selectedRepo && session?.branch && (
                           <div className="flex items-center gap-2 mt-1">
-                            {baseBranch && (
-                              <span className="text-xs text-base-content/50">
-                                📂 Parent: <span className="font-medium">{baseBranch}</span>
-                              </span>
-                            )}
+                            <span className="text-xs text-base-content/50">
+                              📂 <span className="font-medium">{session.branch}</span>
+                            </span>
                           </div>
                         )}
                       </div>


### PR DESCRIPTION
## Summary

Show Current Branch Instead of Parent

## Commits (1)

- `fe45818` Remove parent branch label and show current branch instead - Unified Worker

## Changes

**1** files changed, **4** insertions(+), **6** deletions(-)

### Modified (1)
- website/apps/client/src/pages/Chat.tsx

---

*This pull request was generated automatically*