### PR TITLE
Input Box Busy State on Resumed Conversations

### DIFF
--- a/website/apps/client/src/pages/Chat.tsx
+++ b/website/apps/client/src/pages/Chat.tsx
@@ -502,7 +502,10 @@ export default function Chat({ sessionId: sessionIdProp, isEmbedded = false }: C
         }
       }
     } else if (session?.status === 'completed' || session?.status === 'error') {
-      if (isExecuting) {
+      // Only reset isExecuting if we don't have an active stream
+      // This prevents a race condition where the session status is stale (completed)
+      // but the user just submitted a new request (streamUrl is set)
+      if (isExecuting && !streamUrl) {
         console.log('[Chat] Session completed, setting isExecuting to false');
         setIsExecuting(false);
         // Also clear the global worker store
@@ -510,7 +513,7 @@ export default function Chat({ sessionId: sessionIdProp, isEmbedded = false }: C
         console.log('[Chat] Cleared worker store for completed/errored session');
       }
     }
-  }, [session?.status, isExecuting, currentSessionId]);
+  }, [session?.status, isExecuting, currentSessionId, streamUrl]);
 
   // Load current session details to check if locked
   const { data: currentSessionData } = useQuery({


### PR DESCRIPTION
## Summary

Input Box Busy State on Resumed Conversations

## Commits (2)

- `532e558` Fix input busy state by properly disconnecting previous SSE connections - Unified Worker
- `e63ab96` Fix input busy state for resumed messages by preventing stale closures - Unified Worker

## Changes

**2** files changed, **68** insertions(+), **33** deletions(-)

### Modified (2)
- website/apps/client/src/hooks/useEventSource.ts
- website/apps/client/src/pages/Chat.tsx

---

*This pull request was generated automatically*