### PR TITLE
Add file count display to chat interface

### DIFF
--- a/ai-coding-worker/src/orchestrator.ts
+++ b/ai-coding-worker/src/orchestrator.ts
@@ -357,7 +357,20 @@ export class Orchestrator {
         timestamp: new Date().toISOString()
       });
 
-      await this.storageClient.uploadSession(websiteSessionId, sessionRoot);
+      await this.storageClient.uploadSession(
+        websiteSessionId,
+        sessionRoot,
+        (stage, message, data) => {
+          // Send progress events to client for visibility into upload process
+          sendEvent({
+            type: 'message',
+            stage: `upload_${stage}`,
+            message,
+            data,
+            timestamp: new Date().toISOString()
+          });
+        }
+      );
 
       logger.info('Session uploaded to storage', {
         component: 'Orchestrator',


### PR DESCRIPTION
- Add progress callbacks to storageClient uploadSession method
- Display file counts during upload in orchestrator (ai-coding-worker)
- Add file count display in execute.ts when saving session to storage
- Re-implement create-code-session to clone repository and upload files
  - Now requires GitHub access token
  - Calls initSession() to clone, create branch, and upload to storage
  - Returns branch name and session title in response