### PR TITLE
Fix Duplicate Root Folder in Image Editor

### DIFF
--- a/website/client/package-lock.json
+++ b/website/client/package-lock.json
@@ -33,7 +33,7 @@
         "daisyui": "^5.5.5",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
-        "typescript": "^5.9.3",
+        "typescript": "5.7.2",
         "vite": "^6.4.1"
       }
     },
@@ -5287,9 +5287,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/website/client/package.json
+++ b/website/client/package.json
@@ -34,7 +34,7 @@
     "daisyui": "^5.5.5",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.9.3",
+    "typescript": "5.7.2",
     "vite": "^6.4.1"
   }
 }


### PR DESCRIPTION
## Summary

Fix Duplicate Root Folder in Image Editor

## Commits (2)

- `3f740f2` Fix duplicate root folder display in Images tree - Internal API Server
- `9809893` Fix duplicate root folder display by including repo name in storage paths - Internal API Server

## Changes

**3** files changed, **71** insertions(+), **25** deletions(-)

### Modified (3)
- website/client/package-lock.json
- website/client/package.json
- website/client/src/pages/Images.tsx

---

*This pull request was generated automatically*