### PR TITLE
Add input validation for codebase analysis parameters

### DIFF
--- a/autonomous-dev-cli/src/config/index.ts
+++ b/autonomous-dev-cli/src/config/index.ts
@@ -478,6 +478,8 @@ export function loadConfig(configPath?: string): Config {
     maxOpenIssues: parseInt(process.env.MAX_OPEN_ISSUES || '10', 10),
     excludePaths: process.env.EXCLUDE_PATHS?.split(',') || defaultConfig.discovery?.excludePaths || [],
     issueLabel: process.env.ISSUE_LABEL || 'autonomous-dev',
+    maxDepth: parseInt(process.env.MAX_DEPTH || '10', 10),
+    maxFiles: parseInt(process.env.MAX_FILES || '10000', 10),
   };
 
   envConfig.execution = {

--- a/autonomous-dev-cli/src/config/schema.ts
+++ b/autonomous-dev-cli/src/config/schema.ts
@@ -44,6 +44,16 @@ export const ConfigSchema = z.object({
     ]),
     /** Label applied to auto-created GitHub issues */
     issueLabel: z.string().default('autonomous-dev'),
+    /** Maximum directory depth for codebase scanning (1-20, default: 10) */
+    maxDepth: z.number()
+      .min(1, 'maxDepth must be at least 1')
+      .max(20, 'maxDepth cannot exceed 20 to prevent excessive recursion')
+      .default(10),
+    /** Maximum number of files to scan (100-50000, default: 10000) */
+    maxFiles: z.number()
+      .min(100, 'maxFiles must be at least 100')
+      .max(50000, 'maxFiles cannot exceed 50000 to prevent memory issues')
+      .default(10000),
   }).describe('Task discovery configuration'),
 
   /**
@@ -139,6 +149,8 @@ export const defaultConfig: Partial<Config> = {
     maxOpenIssues: 10,
     excludePaths: ['node_modules', 'dist', '.git', 'coverage', '*.lock'],
     issueLabel: 'autonomous-dev',
+    maxDepth: 10,
+    maxFiles: 10000,
   },
   execution: {
     parallelWorkers: 4,

--- a/autonomous-dev-cli/src/discovery/generator.ts
+++ b/autonomous-dev-cli/src/discovery/generator.ts
@@ -1,4 +1,4 @@
-import { CodebaseAnalyzer, type CodebaseAnalysis } from './analyzer.js';
+import { CodebaseAnalyzer, type CodebaseAnalysis, type AnalyzerConfig } from './analyzer.js';
 import { type Issue } from '../github/issues.js';
 import { logger } from '../utils/logger.js';
 
@@ -21,6 +21,7 @@ export interface TaskGeneratorOptions {
   tasksPerCycle: number;
   existingIssues: Issue[];
   repoContext?: string; // Optional context about what the repo does
+  analyzerConfig?: AnalyzerConfig; // Optional analyzer configuration (maxDepth, maxFiles)
 }
 
 export class TaskGenerator {
@@ -30,6 +31,7 @@ export class TaskGenerator {
   private tasksPerCycle: number;
   private existingIssues: Issue[];
   private repoContext: string;
+  private analyzerConfig: AnalyzerConfig;
 
   constructor(options: TaskGeneratorOptions) {
     this.claudeAuth = options.claudeAuth;
@@ -38,13 +40,14 @@ export class TaskGenerator {
     this.tasksPerCycle = options.tasksPerCycle;
     this.existingIssues = options.existingIssues;
     this.repoContext = options.repoContext || '';
+    this.analyzerConfig = options.analyzerConfig || {};
   }
 
   async generateTasks(): Promise<DiscoveredTask[]> {
     logger.info('Generating tasks with Claude...');
 
     // First, analyze the codebase
-    const analyzer = new CodebaseAnalyzer(this.repoPath, this.excludePaths);
+    const analyzer = new CodebaseAnalyzer(this.repoPath, this.excludePaths, this.analyzerConfig);
     const analysis = await analyzer.analyze();
     const summary = analyzer.generateSummary(analysis);
 

--- a/autonomous-dev-cli/src/discovery/index.ts
+++ b/autonomous-dev-cli/src/discovery/index.ts
@@ -1,2 +1,2 @@
-export { CodebaseAnalyzer, type CodebaseAnalysis, type DirectoryEntry, type TodoComment, type PackageInfo } from './analyzer.js';
+export { CodebaseAnalyzer, type CodebaseAnalysis, type DirectoryEntry, type TodoComment, type PackageInfo, type AnalyzerConfig, type ValidationResult } from './analyzer.js';
 export { TaskGenerator, discoverTasks, type DiscoveredTask, type TaskGeneratorOptions } from './generator.js';


### PR DESCRIPTION
## Summary

Implements #328

## Description

The CodebaseAnalyzer in src/discovery/analyzer.ts currently processes directory paths and file patterns without proper validation, which can lead to runtime errors when scanning invalid paths or when depth/file limits are exceeded. Add comprehensive input validation to:

- Validate directory paths exist and are readable before scanning
- Sanitize file glob patterns to prevent ReDoS attacks
- Enforce reasonable bounds on maxDepth (1-20) and maxFiles (100-50000)
- Add early validation for ignore patterns to ensure they compile as valid regex
- Return meaningful error messages for invalid configurations

Why it's important:
- Prevents runtime crashes when daemon encounters invalid repo structures
- Improves error messages for debugging configuration issues
- Adds security guardrails against malicious path inputs
- Makes the system more robust for diverse repository layouts

Acceptance criteria:
- All analyzer methods validate inputs before processing
- Invalid paths return clear error messages instead of throwing
- Malformed glob patterns are caught and reported
- Configuration bounds are enforced with helpful error messages
- No breaking changes to existing valid usage patterns

## Affected Paths

- `src/discovery/analyzer.ts`
- `src/config/schema.ts`

---

*🤖 This issue was automatically created by Autonomous Dev CLI*


## Changes

*Changes were implemented autonomously by Claude.*

---

🤖 Generated by [Autonomous Dev CLI](https://github.com/webedt/monorepo/tree/main/autonomous-dev-cli)
