### PR TITLE
Add comprehensive error type system and structured error handling

### DIFF
--- a/autonomous-dev-cli/src/db/index.ts
+++ b/autonomous-dev-cli/src/db/index.ts
@@ -10,6 +10,7 @@ import {
   getTimeoutFromEnv,
   TimeoutError,
 } from '../utils/timeout.js';
+import { getErrorMessage } from '../utils/errors.js';
 
 const { Pool } = pg;
 
@@ -399,8 +400,8 @@ export async function closeDatabase(options: CloseDatabaseOptions = {}): Promise
   // Flush any pending activity updates before closing
   try {
     await flushActivityUpdates();
-  } catch (error: any) {
-    logger.warn(`Failed to flush activity updates: ${error.message}`);
+  } catch (error: unknown) {
+    logger.warn(`Failed to flush activity updates: ${getErrorMessage(error)}`);
   }
 
   const stats = getPoolStats();
@@ -427,8 +428,9 @@ export async function closeDatabase(options: CloseDatabaseOptions = {}): Promise
     pool = null;
     db = null;
     logger.info('Database connection closed gracefully');
-  } catch (error: any) {
-    if (error.message.includes('timeout')) {
+  } catch (error: unknown) {
+    const errorMsg = getErrorMessage(error);
+    if (errorMsg.includes('timeout')) {
       logger.warn(`Database close timed out after ${timeoutMs}ms`);
 
       if (force) {
@@ -451,7 +453,7 @@ export async function closeDatabase(options: CloseDatabaseOptions = {}): Promise
         throw error;
       }
     } else {
-      logger.error(`Database close error: ${error.message}`);
+      logger.error(`Database close error: ${errorMsg}`);
       throw error;
     }
   }

--- a/autonomous-dev-cli/src/executor/worker.ts
+++ b/autonomous-dev-cli/src/executor/worker.ts
@@ -36,6 +36,7 @@ import {
   ErrorCode,
   wrapError,
   withRetry,
+  getErrorMessage,
   type ErrorContext,
   type RecoveryAction,
 } from '../utils/errors.js';
@@ -398,8 +399,8 @@ export class Worker {
           correlationId,
           workerId: this.workerId,
         });
-      } catch (error: any) {
-        taskLog.warn(`Failed to create chat session: ${error.message}`);
+      } catch (error: unknown) {
+        taskLog.warn(`Failed to create chat session: ${getErrorMessage(error)}`);
       }
     }
 
@@ -537,7 +538,7 @@ export class Worker {
         duration,
         chatSessionId,
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
       // Track execution state at time of failure
       const executionState: Partial<TaskExecutionState> = {
         taskId: `task-${issue.number}`,
@@ -553,7 +554,7 @@ export class Worker {
       const structuredError = this.wrapExecutionError(
         error,
         ErrorCode.INTERNAL_ERROR,
-        `Task execution failed: ${error.message}`,
+        `Task execution failed: ${getErrorMessage(error)}`,
         task,
         executionState
       );


### PR DESCRIPTION
## Summary

Implements #448

## Description

The codebase has 86+ instances of generic error handling with 'any' type usage and inconsistent error detail preservation. Create a typed error system:

- Create `/app/src/utils/errors.ts` with specific error classes: ConfigError, GitHubError, ClaudeError, DatabaseError
- Replace all `catch (error: any)` with typed error handling
- Add error context preservation and structured error details
- Create `withErrorLogging()` higher-order function to reduce duplicate error handling patterns

Acceptance criteria:
- All errors have specific types with meaningful properties
- Error context is preserved through the call stack
- Consistent error logging format across all modules
- No remaining `any` types in error handling blocks

## Affected Paths

- `src/utils/errors.ts`
- `src/utils/middleware.ts`
- `src/daemon.ts`
- `src/executor/`
- `src/github/`
- `src/discovery/`
- `src/db/`

---

*🤖 This issue was automatically created by Autonomous Dev CLI*


## Changes

*Changes were implemented autonomously by Claude.*

---

🤖 Generated by [Autonomous Dev CLI](https://github.com/webedt/monorepo/tree/main/autonomous-dev-cli)
