### PR TITLE
Fix TypeScript mock type error in shared logger tests

### DIFF
--- a/shared/src/logger.test.ts
+++ b/shared/src/logger.test.ts
@@ -29,10 +29,10 @@ describe('Logger Module', () => {
     consoleWarnSpy = mock.fn();
     consoleErrorSpy = mock.fn();
 
-    // Replace console methods
-    console.log = consoleLogSpy;
-    console.warn = consoleWarnSpy;
-    console.error = consoleErrorSpy;
+    // Replace console methods (cast to any to bypass strict type checking for mocks)
+    console.log = consoleLogSpy as any;
+    console.warn = consoleWarnSpy as any;
+    console.error = consoleErrorSpy as any;
   });
 
   afterEach(() => {


### PR DESCRIPTION
Cast mock functions to any to bypass strict type checking when assigning to console methods in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)