### PR TITLE
Update Dokploy domain references to webedt

### DIFF
--- a/.github/workflows/website-deploy-dokploy.yml
+++ b/.github/workflows/website-deploy-dokploy.yml
@@ -437,7 +437,7 @@ jobs:
             REPO="${{ steps.metadata.outputs.repo }}"
             PROJECT="${{ steps.metadata.outputs.project }}"
             BRANCH="${{ steps.metadata.outputs.branch }}"
-            DOMAIN="webedit.etdofresh.com"
+            DOMAIN="webedt.etdofresh.com"
             PATH_PREFIX="/github/${OWNER}/${REPO}/${BRANCH}/"
 
             # Check if domain already exists to avoid duplicates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,15 +113,15 @@ The Express server acts as a facade that:
 Path-based routing via Dokploy:
 
 ```
-https://webedit.etdofresh.com/github/{owner}/{repo}/{branch}/
+https://webedt.etdofresh.com/github/{owner}/{repo}/{branch}/
 ```
 
 **IMPORTANT:** For branch names containing slashes (`/`), replace them with hyphens (`-`) in the URL.
 
 **Examples:**
-- `https://webedit.etdofresh.com/github/webedt/monorepo/main/`
-- `https://webedit.etdofresh.com/github/webedt/monorepo/feature-branch/`
-- Branch `claude/fix-bug-123` → `https://webedit.etdofresh.com/github/webedt/monorepo/claude-fix-bug-123/`
+- `https://webedt.etdofresh.com/github/webedt/monorepo/main/`
+- `https://webedt.etdofresh.com/github/webedt/monorepo/feature-branch/`
+- Branch `claude/fix-bug-123` → `https://webedt.etdofresh.com/github/webedt/monorepo/claude-fix-bug-123/`
 
 ---
 
@@ -420,7 +420,7 @@ docker service logs <service-name> -f
 **Links:**
 
 GitHub Branch: [https://github.com/webedt/monorepo/tree/{branch}](https://github.com/webedt/monorepo/tree/{branch})
-Live Site: [https://webedit.etdofresh.com/github/webedt/monorepo/{branch-with-slashes-as-hyphens}/](https://webedit.etdofresh.com/github/webedt/monorepo/{branch-with-slashes-as-hyphens}/)
+Live Site: [https://webedt.etdofresh.com/github/webedt/monorepo/{branch-with-slashes-as-hyphens}/](https://webedt.etdofresh.com/github/webedt/monorepo/{branch-with-slashes-as-hyphens}/)
 ```
 
 **NOTE:** For the Live Site URL, replace any slashes (`/`) in the branch name with hyphens (`-`).

--- a/internal-api-server/src/utils/previewUrlHelper.ts
+++ b/internal-api-server/src/utils/previewUrlHelper.ts
@@ -19,7 +19,7 @@ interface WebedtConfig {
  *
  * Priority:
  * 1. Check for .webedt file in repository root and use preview_url if exists
- * 2. Fall back to default: https://webedit.etdofresh.com/github/{owner}/{repo}/{branch}/
+ * 2. Fall back to default: https://webedt.etdofresh.com/github/{owner}/{repo}/{branch}/
  *
  * @param workspacePath - Path to the git repository workspace (optional)
  * @param owner - Repository owner
@@ -56,7 +56,7 @@ export async function getPreviewUrl(
     // Use default preview URL
     // Replace forward slashes in branch name with dashes for URL safety
     const safeBranch = branch.replace(/\//g, '-');
-    const defaultUrl = `https://webedit.etdofresh.com/github/${owner}/${repo}/${safeBranch}/`;
+    const defaultUrl = `https://webedt.etdofresh.com/github/${owner}/${repo}/${safeBranch}/`;
     console.log('[PreviewUrlHelper] Using default preview URL:', defaultUrl);
 
     return defaultUrl;
@@ -66,7 +66,7 @@ export async function getPreviewUrl(
     // Return default URL even on error
     // Replace forward slashes in branch name with dashes for URL safety
     const safeBranch = branch.replace(/\//g, '-');
-    return `https://webedit.etdofresh.com/github/${owner}/${repo}/${safeBranch}/`;
+    return `https://webedt.etdofresh.com/github/${owner}/${repo}/${safeBranch}/`;
   }
 }
 

--- a/shared/src/previewUrlHelper.ts
+++ b/shared/src/previewUrlHelper.ts
@@ -20,7 +20,7 @@ interface WebedtConfig {
  *
  * Priority:
  * 1. Check for .webedt file in repository root and use preview_url if exists
- * 2. Fall back to default: https://webedit.etdofresh.com/github/{owner}/{repo}/{branch}/
+ * 2. Fall back to default: https://webedt.etdofresh.com/github/{owner}/{repo}/{branch}/
  *
  * @param workspacePath - Path to the git repository workspace (optional)
  * @param owner - Repository owner
@@ -62,7 +62,7 @@ export async function getPreviewUrl(
     // Use default preview URL
     // Replace forward slashes in branch name with dashes for URL safety
     const safeBranch = branch.replace(/\//g, '-');
-    const defaultUrl = `https://webedit.etdofresh.com/github/${owner}/${repo}/${safeBranch}/`;
+    const defaultUrl = `https://webedt.etdofresh.com/github/${owner}/${repo}/${safeBranch}/`;
     logger.debug('Using default preview URL', {
       component: 'PreviewUrlHelper',
       previewUrl: defaultUrl
@@ -75,7 +75,7 @@ export async function getPreviewUrl(
     // Return default URL even on error
     // Replace forward slashes in branch name with dashes for URL safety
     const safeBranch = branch.replace(/\//g, '-');
-    return `https://webedit.etdofresh.com/github/${owner}/${repo}/${safeBranch}/`;
+    return `https://webedt.etdofresh.com/github/${owner}/${repo}/${safeBranch}/`;
   }
 }
 

--- a/website/server/src/index.ts
+++ b/website/server/src/index.ts
@@ -21,7 +21,7 @@ if (!INTERNAL_API_URL) {
 
 // CORS configuration
 const ALLOWED_ORIGINS = NODE_ENV === 'production'
-  ? ['https://webedit.etdofresh.com']
+  ? ['https://webedt.etdofresh.com']
   : ['http://localhost:5173', 'http://localhost:3000', 'http://localhost:3001'];
 
 app.use(cors({


### PR DESCRIPTION
- Update preview URL helpers and docs to use webedt domain for generated links and examples
- Adjust website server CORS and deployment workflow configurations to allow the new domain