### PR TITLE
Stream raw remote events directly

### DIFF
--- a/internal-api-server/src/routes/executeRemote.ts
+++ b/internal-api-server/src/routes/executeRemote.ts
@@ -295,24 +295,16 @@ const executeRemoteHandler = async (req: Request, res: Response) => {
     res.setHeader('X-Accel-Buffering', 'no');
 
     // Helper to send SSE events
+    // All events are now passed through directly with the same flat structure
     const sendEvent = async (event: ExecutionEvent) => {
       if (clientDisconnected) return;
 
-      // For raw_event types, pass through without decoration
-      // This allows the frontend to receive events exactly as they come from the API
-      const isRawEvent = event.type === 'raw_event' || (event as any).rawEvent;
-
-      let eventToSend: any;
-      if (isRawEvent) {
-        // Pass through raw event without any transformation
-        eventToSend = event;
-      } else {
-        // Apply emoji decoration for non-raw events
-        eventToSend = {
-          ...event,
-          message: event.message ? `${getEventEmoji(event)} ${event.message}` : undefined,
-        };
-      }
+      // All events have the same flat structure now
+      // Apply emoji decoration for events that have a message field
+      const eventToSend = {
+        ...event,
+        message: event.message ? `${getEventEmoji(event)} ${event.message}` : undefined,
+      };
 
       const eventData = `data: ${JSON.stringify(eventToSend)}\n\n`;
 
@@ -321,7 +313,6 @@ const executeRemoteHandler = async (req: Request, res: Response) => {
         component: 'ExecuteRemoteRoute',
         chatSessionId,
         eventType: event.type,
-        isRawEvent,
         eventData: JSON.stringify(eventToSend),
       });
 

--- a/internal-api-server/src/services/executionProviders/claudeRemoteProvider.ts
+++ b/internal-api-server/src/services/executionProviders/claudeRemoteProvider.ts
@@ -25,18 +25,18 @@ import type {
 } from './types.js';
 
 /**
- * Pass through raw Anthropic session events with minimal wrapping
- * This allows the frontend to receive events exactly as they come from the API
+ * Pass through raw Anthropic session events directly
+ * Flatten the event structure - no wrapper, just add source and timestamp
+ * This keeps remote events at the same level as our intermediary events
  */
 function passRawEvent(event: SessionEvent, source: string): ExecutionEvent {
-  // Pass raw event directly - no mapping, no transformation
-  // Just add source and timestamp for tracking
+  // Spread the event and add our tracking fields
+  // This flattens the structure so all events have the same shape
   return {
-    type: 'raw_event',
+    ...event,
     timestamp: new Date().toISOString(),
     source,
-    rawEvent: event, // The actual raw event from Anthropic API
-  };
+  } as ExecutionEvent;
 }
 
 /**

--- a/internal-api-server/src/services/executionProviders/types.ts
+++ b/internal-api-server/src/services/executionProviders/types.ts
@@ -9,6 +9,7 @@ import type { ClaudeAuth } from '../../lib/claudeAuth.js';
 
 /**
  * Event types emitted during execution
+ * Includes our intermediary event types plus any type from remote sessions
  */
 export type ExecutionEventType =
   | 'connected'
@@ -19,10 +20,12 @@ export type ExecutionEventType =
   | 'title_generation'
   | 'completed'
   | 'error'
-  | 'raw_event';
+  | string; // Allow any type from remote sessions (e.g., 'system', 'user', 'assistant', 'result', etc.)
 
 /**
  * Event emitted during execution
+ * Base fields are always present, but events may include any additional fields
+ * from remote sessions (these are passed through directly without wrapping)
  */
 export interface ExecutionEvent {
   type: ExecutionEventType;
@@ -63,8 +66,9 @@ export interface ExecutionEvent {
   error?: string;
   code?: string;
 
-  // Raw event from provider (for debugging/pass-through)
-  rawEvent?: unknown;
+  // Allow any additional fields from remote sessions
+  // Events are now passed through directly (no raw_event wrapper)
+  [key: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
- Remove raw_event wrapper from claudeRemoteProvider
- Pass through remote session events directly with timestamp/source added
- Update ExecutionEvent types to allow any additional fields from remote sessions
- Simplify sendEvent in executeRemote by removing isRawEvent special handling
- Simplify convertEventToMessage to display all events as raw JSON
- Remove unused formatSourceLabel helper function