### PR TITLE
Fix Docker apt-get update failure

### DIFF
--- a/ai-coding-worker/Dockerfile
+++ b/ai-coding-worker/Dockerfile
@@ -6,11 +6,19 @@ ARG BUILD_TIMESTAMP=unknown
 ARG BUILD_IMAGE_TAG=unknown
 
 # Install git (required for cloning repositories) and GitHub CLI (for Copilot)
-RUN apt-get update && apt-get install -y git curl && \
+# Uses retry logic for transient network failures
+RUN for i in 1 2 3 4 5; do \
+        rm -rf /var/lib/apt/lists/* && \
+        apt-get update && \
+        apt-get install -y git curl && \
+        break || { echo "Retry $i/5 apt install failed, waiting $((i * 2))s..."; sleep $((i * 2)); }; \
+    done && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update && apt-get install -y gh && \
+    for i in 1 2 3 4 5; do \
+        apt-get update && apt-get install -y gh && break || { echo "Retry $i/5 gh install failed, waiting $((i * 2))s..."; sleep $((i * 2)); }; \
+    done && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Gemini CLI globally (for OAuth-based Gemini access)

--- a/internal-api-server/Dockerfile
+++ b/internal-api-server/Dockerfile
@@ -6,7 +6,14 @@ ARG BUILD_TIMESTAMP=unknown
 ARG BUILD_IMAGE_TAG=unknown
 
 # Install git, python3, and build tools (needed for bcrypt native compilation on ARM64)
-RUN apt-get update && apt-get install -y git python3 make g++ && rm -rf /var/lib/apt/lists/*
+# Uses retry logic for transient network failures
+RUN for i in 1 2 3 4 5; do \
+        rm -rf /var/lib/apt/lists/* && \
+        apt-get update && \
+        apt-get install -y git python3 make g++ && \
+        break || { echo "Retry $i/5 apt install failed, waiting $((i * 2))s..."; sleep $((i * 2)); }; \
+    done && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
- Add cache-busting echo before apt-get to invalidate Docker cache
- Retry entire apt-get update && install process (not just update)
- Clear apt lists between retry attempts
- Apply consistent retry pattern to all Dockerfiles