### PR TITLE
Standardize internal API server port to 3001

### DIFF
--- a/internal-api-server/Dockerfile
+++ b/internal-api-server/Dockerfile
@@ -40,14 +40,14 @@ COPY internal-api-server/src ./src
 RUN npm run build
 
 # Set environment variables
-ENV PORT=3000
+ENV PORT=3001
 ENV NODE_ENV=production
 ENV BUILD_COMMIT_SHA=$BUILD_COMMIT_SHA
 ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 ENV BUILD_IMAGE_TAG=$BUILD_IMAGE_TAG
 
 # Expose port
-EXPOSE 3000
+EXPOSE 3001
 
 # Start the server
 CMD ["npm", "start"]

--- a/internal-api-server/docker-compose.yml
+++ b/internal-api-server/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      PORT: 3000
+      PORT: 3001
       NODE_ENV: production
 
       # Database (external PostgreSQL)


### PR DESCRIPTION
## Summary
- Update Dockerfile ENV PORT and EXPOSE from 3000 to 3001
- Update docker-compose.yml PORT from 3000 to 3001
- Aligns Docker configuration with the code default in `src/config/env.ts`

This ensures the internal API server uses port 3001 consistently in both development and production environments.

## Test plan
- [ ] Deploy internal-api-server and verify it starts on port 3001
- [ ] Update website's `INTERNAL_API_URL` environment variable in Dokploy to use port 3001
- [ ] Verify login and API calls work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)