### PR TITLE
Add /api/logs endpoint for server debugging

### DIFF
--- a/internal-api-server/src/index.ts
+++ b/internal-api-server/src/index.ts
@@ -39,6 +39,7 @@ import transcribeRoutes from './routes/transcribe.js';
 import completionsRoutes from './routes/completions.js';
 import imageGenRoutes from './routes/imageGen.js';
 import internalSessionsRoutes from './routes/internalSessions.js';
+import logsRoutes from './routes/logs.js';
 
 // Import database for orphan cleanup
 import { db, chatSessions, events, checkHealth as checkDbHealth, getConnectionStats } from './db/index.js';
@@ -312,6 +313,7 @@ app.use('/api', transcribeRoutes);
 app.use('/api/completions', completionsRoutes);
 app.use('/api/image-gen', imageGenRoutes);
 app.use('/api/internal/sessions', internalSessionsRoutes);  // Claude Remote Sessions management
+app.use('/api', logsRoutes);  // Debug logs endpoint
 
 // Note: Static file serving removed - handled by website-server facade
 
@@ -404,6 +406,10 @@ app.listen(PORT, () => {
   console.log('  POST /api/internal/sessions/:id/archive- Archive session');
   console.log('  DELETE /api/internal/sessions/:id      - Delete session from DB');
   console.log('  POST /api/internal/sessions/:id/interrupt - Interrupt session');
+  console.log('');
+  console.log('  GET  /api/logs                         - Get captured logs');
+  console.log('  DELETE /api/logs                       - Clear captured logs');
+  console.log('  GET  /api/logs/status                  - Get log capture status');
   console.log('='.repeat(60));
 
   // Schedule periodic orphan cleanup

--- a/internal-api-server/src/routes/logs.ts
+++ b/internal-api-server/src/routes/logs.ts
@@ -1,0 +1,102 @@
+/**
+ * Logs endpoint for debugging
+ * Exposes captured server logs via API
+ *
+ * NOTE: This endpoint should be disabled in production
+ */
+
+import { Router } from 'express';
+import { logCapture, logger } from '@webedt/shared';
+
+const router = Router();
+
+/**
+ * GET /api/logs
+ * Returns captured server logs with optional filtering
+ *
+ * Query parameters:
+ * - level: Filter by log level (debug, info, warn, error)
+ * - component: Filter by component name
+ * - sessionId: Filter by session ID
+ * - since: Filter logs after this ISO timestamp
+ * - limit: Maximum number of logs to return (default: 100, max: 1000)
+ *
+ * Response:
+ * - success: boolean
+ * - data: { logs: CapturedLog[], total: number, filtered: number, status: { enabled, count, maxLogs } }
+ */
+router.get('/logs', (req, res) => {
+  try {
+    const { level, component, sessionId, since, limit } = req.query;
+
+    const result = logCapture.getLogs({
+      level: level as string | undefined,
+      component: component as string | undefined,
+      sessionId: sessionId as string | undefined,
+      since: since as string | undefined,
+      limit: limit ? parseInt(limit as string, 10) : undefined,
+    });
+
+    const status = logCapture.getStatus();
+
+    res.json({
+      success: true,
+      data: {
+        ...result,
+        status,
+      },
+    });
+  } catch (error) {
+    logger.error('Error fetching logs:', error);
+    res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to fetch logs',
+    });
+  }
+});
+
+/**
+ * DELETE /api/logs
+ * Clears all captured logs
+ */
+router.delete('/logs', (req, res) => {
+  try {
+    logCapture.clear();
+    logger.info('Logs cleared via API');
+
+    res.json({
+      success: true,
+      data: {
+        message: 'Logs cleared successfully',
+      },
+    });
+  } catch (error) {
+    logger.error('Error clearing logs:', error);
+    res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to clear logs',
+    });
+  }
+});
+
+/**
+ * GET /api/logs/status
+ * Returns log capture status
+ */
+router.get('/logs/status', (req, res) => {
+  try {
+    const status = logCapture.getStatus();
+
+    res.json({
+      success: true,
+      data: status,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to get log status',
+    });
+  }
+});
+
+export default router;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -9,6 +9,10 @@ export type { SessionMetadata, StorageSessionInfo, AIProvider } from './types.js
 export { logger } from './logger.js';
 export type { LogContext } from './logger.js';
 
+// Log Capture (for /api/logs endpoint)
+export { logCapture } from './logCapture.js';
+export type { CapturedLog, LogFilter } from './logCapture.js';
+
 // Emoji Mapper
 export { getEventEmoji, applyEmoji } from './emojiMapper.js';
 

--- a/shared/src/logCapture.ts
+++ b/shared/src/logCapture.ts
@@ -1,0 +1,152 @@
+/**
+ * In-memory log capture for debugging
+ * Captures logs in a circular buffer for retrieval via API
+ */
+
+export interface CapturedLog {
+  timestamp: string;
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  context?: Record<string, unknown>;
+  error?: {
+    message: string;
+    stack?: string;
+  };
+}
+
+export interface LogFilter {
+  level?: string;
+  component?: string;
+  sessionId?: string;
+  since?: string;
+  limit?: number;
+}
+
+class LogCapture {
+  private logs: CapturedLog[] = [];
+  private maxLogs: number = 5000;
+  private enabled: boolean = true;
+
+  /**
+   * Capture a log entry
+   */
+  capture(
+    level: CapturedLog['level'],
+    message: string,
+    context?: Record<string, unknown>,
+    error?: Error | unknown
+  ): void {
+    if (!this.enabled) return;
+
+    const entry: CapturedLog = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      context,
+    };
+
+    if (error) {
+      if (error instanceof Error) {
+        entry.error = {
+          message: error.message,
+          stack: error.stack,
+        };
+      } else {
+        entry.error = {
+          message: String(error),
+        };
+      }
+    }
+
+    this.logs.push(entry);
+
+    // Circular buffer - remove oldest logs if over limit
+    if (this.logs.length > this.maxLogs) {
+      this.logs = this.logs.slice(-this.maxLogs);
+    }
+  }
+
+  /**
+   * Get logs with optional filtering
+   */
+  getLogs(filter?: LogFilter): { logs: CapturedLog[]; total: number; filtered: number } {
+    const total = this.logs.length;
+    let filtered = this.logs;
+
+    if (filter) {
+      if (filter.level) {
+        filtered = filtered.filter(log => log.level === filter.level);
+      }
+
+      if (filter.component) {
+        filtered = filtered.filter(
+          log => log.context?.component === filter.component
+        );
+      }
+
+      if (filter.sessionId) {
+        filtered = filtered.filter(
+          log => log.context?.sessionId === filter.sessionId
+        );
+      }
+
+      if (filter.since) {
+        const sinceDate = new Date(filter.since);
+        filtered = filtered.filter(
+          log => new Date(log.timestamp) >= sinceDate
+        );
+      }
+
+      // Apply limit (default to 100, max 1000)
+      const limit = Math.min(filter.limit || 100, 1000);
+      filtered = filtered.slice(-limit);
+    } else {
+      // Default: return last 100 logs
+      filtered = filtered.slice(-100);
+    }
+
+    return {
+      logs: filtered,
+      total,
+      filtered: filtered.length,
+    };
+  }
+
+  /**
+   * Clear all captured logs
+   */
+  clear(): void {
+    this.logs = [];
+  }
+
+  /**
+   * Set maximum number of logs to retain
+   */
+  setMaxLogs(max: number): void {
+    this.maxLogs = max;
+    if (this.logs.length > this.maxLogs) {
+      this.logs = this.logs.slice(-this.maxLogs);
+    }
+  }
+
+  /**
+   * Enable or disable log capture
+   */
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  /**
+   * Get capture status
+   */
+  getStatus(): { enabled: boolean; count: number; maxLogs: number } {
+    return {
+      enabled: this.enabled,
+      count: this.logs.length,
+      maxLogs: this.maxLogs,
+    };
+  }
+}
+
+// Singleton instance
+export const logCapture = new LogCapture();

--- a/shared/src/logger.ts
+++ b/shared/src/logger.ts
@@ -2,6 +2,8 @@
  * Simple structured logger for WebEDT services
  */
 
+import { logCapture } from './logCapture.js';
+
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 interface LogContext {
@@ -39,20 +41,24 @@ class Logger {
   }
 
   debug(message: string, context?: LogContext): void {
+    logCapture.capture('debug', message, context);
     if (process.env.LOG_LEVEL === 'debug') {
       console.log(this.formatMessage('debug', message, context));
     }
   }
 
   info(message: string, context?: LogContext): void {
+    logCapture.capture('info', message, context);
     console.log(this.formatMessage('info', message, context));
   }
 
   warn(message: string, context?: LogContext): void {
+    logCapture.capture('warn', message, context);
     console.warn(this.formatMessage('warn', message, context));
   }
 
   error(message: string, error?: Error | unknown, context?: LogContext): void {
+    logCapture.capture('error', message, context, error);
     console.error(this.formatMessage('error', message, context));
     if (error) {
       if (error instanceof Error) {

--- a/website/server/src/index.ts
+++ b/website/server/src/index.ts
@@ -59,6 +59,7 @@ const ALLOWED_API_ROUTES = [
   '/api/transcribe',     // Audio transcription
   '/api/admin',          // Admin (requires admin auth anyway)
   '/api/storage',        // Storage operations (file listing, read, write, delete)
+  '/api/logs',           // Debug logs (for debugging, may disable in production)
 ];
 
 // Block internal-only routes explicitly


### PR DESCRIPTION
## Summary

- Add in-memory log capture utility with circular buffer (5000 max entries) to prevent memory leaks
- Integrate log capture with the existing shared logger - all logs are now captured
- Add `/api/logs` endpoint with filtering support (level, component, sessionId, since, limit)
- Add `/api/logs/status` for capture status and `DELETE /api/logs` to clear logs
- Whitelist `/api/logs` in the website facade for public access

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/logs` | Get logs with optional filters |
| DELETE | `/api/logs` | Clear all captured logs |
| GET | `/api/logs/status` | Get capture status |

### Query Parameters for GET /api/logs

- `level` - Filter by log level (debug, info, warn, error)
- `component` - Filter by component name
- `sessionId` - Filter by session ID
- `since` - ISO timestamp to filter logs after
- `limit` - Max logs to return (default: 100, max: 1000)

## Test plan

- [ ] Deploy to staging and verify `/api/logs` returns captured logs
- [ ] Test filtering by level (`?level=error`)
- [ ] Test clearing logs via DELETE
- [ ] Verify logs don't grow unbounded (circular buffer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)