### PR TITLE
Replace polling with SSE for session list updates

### DIFF
--- a/internal-api-server/src/lib/sessionListBroadcaster.ts
+++ b/internal-api-server/src/lib/sessionListBroadcaster.ts
@@ -1,0 +1,156 @@
+/**
+ * SessionListBroadcaster
+ *
+ * A pub/sub system for broadcasting session list updates to connected clients.
+ * This allows clients to receive real-time updates when sessions are created,
+ * updated, or change status - eliminating the need for polling.
+ *
+ * Use case: When a session status changes (e.g., running -> completed),
+ * all connected clients for that user receive the update immediately.
+ */
+
+import { EventEmitter } from 'events';
+import { logger } from '@webedt/shared';
+import type { ChatSession } from '../db/schema.js';
+
+export type SessionUpdateType = 'created' | 'updated' | 'deleted' | 'status_changed';
+
+export interface SessionListEvent {
+  type: SessionUpdateType;
+  session: Partial<ChatSession> & { id: string };
+  timestamp: Date;
+}
+
+interface Subscriber {
+  id: string;
+  callback: (event: SessionListEvent) => void;
+}
+
+class SessionListBroadcaster extends EventEmitter {
+  // Map of userId -> array of subscribers
+  private subscribers: Map<string, Subscriber[]> = new Map();
+
+  constructor() {
+    super();
+    // Increase max listeners since we may have many users
+    this.setMaxListeners(1000);
+  }
+
+  /**
+   * Subscribe to session list updates for a specific user
+   * Returns an unsubscribe function
+   */
+  subscribe(userId: string, subscriberId: string, callback: (event: SessionListEvent) => void): () => void {
+    if (!this.subscribers.has(userId)) {
+      this.subscribers.set(userId, []);
+    }
+
+    const subscriber: Subscriber = { id: subscriberId, callback };
+    this.subscribers.get(userId)!.push(subscriber);
+
+    logger.info(`Subscriber ${subscriberId} subscribed to session list updates for user ${userId}`, {
+      component: 'SessionListBroadcaster',
+      subscriberCount: this.subscribers.get(userId)!.length
+    });
+
+    // Return unsubscribe function
+    return () => {
+      const subs = this.subscribers.get(userId);
+      if (subs) {
+        const index = subs.findIndex(s => s.id === subscriberId);
+        if (index !== -1) {
+          subs.splice(index, 1);
+          logger.info(`Subscriber ${subscriberId} unsubscribed from session list updates for user ${userId}`, {
+            component: 'SessionListBroadcaster'
+          });
+        }
+        // Clean up empty subscriber arrays
+        if (subs.length === 0) {
+          this.subscribers.delete(userId);
+        }
+      }
+    };
+  }
+
+  /**
+   * Broadcast a session list update to all subscribers for a user
+   */
+  broadcast(userId: string, type: SessionUpdateType, session: Partial<ChatSession> & { id: string }): void {
+    const subscribers = this.subscribers.get(userId);
+    if (!subscribers || subscribers.length === 0) {
+      return; // No subscribers, skip
+    }
+
+    const event: SessionListEvent = {
+      type,
+      session,
+      timestamp: new Date(),
+    };
+
+    logger.info(`Broadcasting session ${type} event for user ${userId}`, {
+      component: 'SessionListBroadcaster',
+      sessionId: session.id,
+      status: session.status,
+      subscriberCount: subscribers.length
+    });
+
+    subscribers.forEach(sub => {
+      try {
+        sub.callback(event);
+      } catch (err) {
+        logger.error(`Error broadcasting to subscriber ${sub.id}`, err as Error, {
+          component: 'SessionListBroadcaster'
+        });
+      }
+    });
+  }
+
+  /**
+   * Notify when a session is created
+   */
+  notifySessionCreated(userId: string, session: Partial<ChatSession> & { id: string }): void {
+    this.broadcast(userId, 'created', session);
+  }
+
+  /**
+   * Notify when a session is updated (title, branch, etc.)
+   */
+  notifySessionUpdated(userId: string, session: Partial<ChatSession> & { id: string }): void {
+    this.broadcast(userId, 'updated', session);
+  }
+
+  /**
+   * Notify when a session status changes (running -> completed, etc.)
+   */
+  notifyStatusChanged(userId: string, session: Partial<ChatSession> & { id: string }): void {
+    this.broadcast(userId, 'status_changed', session);
+  }
+
+  /**
+   * Notify when a session is deleted
+   */
+  notifySessionDeleted(userId: string, sessionId: string): void {
+    this.broadcast(userId, 'deleted', { id: sessionId });
+  }
+
+  /**
+   * Get subscriber count for a user
+   */
+  getSubscriberCount(userId: string): number {
+    return this.subscribers.get(userId)?.length || 0;
+  }
+
+  /**
+   * Get total subscriber count across all users
+   */
+  getTotalSubscriberCount(): number {
+    let total = 0;
+    for (const subs of this.subscribers.values()) {
+      total += subs.length;
+    }
+    return total;
+  }
+}
+
+// Export a singleton instance
+export const sessionListBroadcaster = new SessionListBroadcaster();

--- a/website/client/src/components/SessionsSidebar.tsx
+++ b/website/client/src/components/SessionsSidebar.tsx
@@ -6,6 +6,7 @@ import { useAuthStore, useSessionLastPageStore, useSessionsSidebarStore, type Se
 import type { ChatSession, GitHubRepository } from '@/shared';
 import { truncateSessionName } from '@/lib/utils';
 import type { ImageAttachment } from './ChatInput';
+import { useSessionListUpdates } from '@/hooks/useSessionListUpdates';
 
 // Helper to get the session URL with last visited page
 function getSessionUrl(sessionId: string, getLastPage: (id: string) => string): string {
@@ -59,12 +60,10 @@ export default function SessionsSidebar() {
   const { data, isLoading } = useQuery({
     queryKey: ['sessions'],
     queryFn: sessionsApi.list,
-    refetchInterval: (query) => {
-      const sessions = query.state.data?.data?.sessions || [];
-      const hasRunning = sessions.some((s: ChatSession) => s.status === 'running');
-      return hasRunning ? 3000 : false;
-    },
   });
+
+  // Subscribe to real-time session updates via SSE (replaces polling)
+  useSessionListUpdates();
 
   const sessions: ChatSession[] = data?.data?.sessions || [];
 

--- a/website/client/src/hooks/useSessionListUpdates.ts
+++ b/website/client/src/hooks/useSessionListUpdates.ts
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { getApiBaseUrl } from '@/lib/api';
+
+/**
+ * Session list update event types from the server
+ */
+export type SessionUpdateType = 'created' | 'updated' | 'deleted' | 'status_changed';
+
+export interface SessionListEvent {
+  type: SessionUpdateType;
+  session: {
+    id: string;
+    status?: string;
+    userRequest?: string;
+    [key: string]: unknown;
+  };
+  timestamp: string;
+}
+
+interface UseSessionListUpdatesOptions {
+  /** Whether to enable the SSE connection (default: true) */
+  enabled?: boolean;
+  /** Callback when a session update is received */
+  onUpdate?: (event: SessionListEvent) => void;
+}
+
+/**
+ * Hook to subscribe to real-time session list updates via SSE.
+ *
+ * This eliminates the need for polling the sessions list by receiving
+ * push notifications when sessions are created, updated, or change status.
+ *
+ * The hook automatically invalidates the React Query cache for the 'sessions'
+ * query key when updates are received, triggering a refetch.
+ *
+ * @example
+ * ```tsx
+ * // Basic usage - just invalidates the sessions query
+ * useSessionListUpdates();
+ *
+ * // With custom callback
+ * useSessionListUpdates({
+ *   onUpdate: (event) => {
+ *     console.log('Session updated:', event);
+ *   }
+ * });
+ * ```
+ */
+export function useSessionListUpdates(options: UseSessionListUpdatesOptions = {}) {
+  const { enabled = true, onUpdate } = options;
+  const queryClient = useQueryClient();
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout>();
+  const reconnectAttemptRef = useRef(0);
+  const maxReconnectAttempts = 5;
+
+  // Use ref to avoid stale closure issues
+  const onUpdateRef = useRef(onUpdate);
+  useEffect(() => {
+    onUpdateRef.current = onUpdate;
+  });
+
+  const connect = useCallback(() => {
+    if (eventSourceRef.current) {
+      return; // Already connected
+    }
+
+    const url = `${getApiBaseUrl()}/api/sessions/updates`;
+    console.log('[SessionListUpdates] Connecting to:', url);
+
+    const eventSource = new EventSource(url, { withCredentials: true });
+    eventSourceRef.current = eventSource;
+
+    eventSource.onopen = () => {
+      console.log('[SessionListUpdates] Connected');
+      reconnectAttemptRef.current = 0;
+    };
+
+    // Handle the 'connected' event (initial connection confirmation)
+    eventSource.addEventListener('connected', (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        console.log('[SessionListUpdates] Connection confirmed:', data);
+      } catch {
+        // Ignore parse errors
+      }
+    });
+
+    // Handle session events
+    const handleSessionEvent = (eventType: SessionUpdateType) => (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data) as SessionListEvent;
+        console.log(`[SessionListUpdates] Received ${eventType} event:`, data);
+
+        // Call the user callback if provided
+        onUpdateRef.current?.(data);
+
+        // Invalidate the sessions query to trigger a refetch
+        queryClient.invalidateQueries({ queryKey: ['sessions'] });
+      } catch (err) {
+        console.error('[SessionListUpdates] Error parsing event:', err);
+      }
+    };
+
+    eventSource.addEventListener('created', handleSessionEvent('created'));
+    eventSource.addEventListener('updated', handleSessionEvent('updated'));
+    eventSource.addEventListener('deleted', handleSessionEvent('deleted'));
+    eventSource.addEventListener('status_changed', handleSessionEvent('status_changed'));
+
+    eventSource.onerror = (error) => {
+      console.error('[SessionListUpdates] Error:', error);
+
+      // Close the current connection
+      eventSource.close();
+      eventSourceRef.current = null;
+
+      // Attempt to reconnect with exponential backoff
+      if (reconnectAttemptRef.current < maxReconnectAttempts) {
+        reconnectAttemptRef.current++;
+        const delay = Math.min(1000 * Math.pow(2, reconnectAttemptRef.current), 30000);
+        console.log(`[SessionListUpdates] Reconnecting in ${delay}ms (attempt ${reconnectAttemptRef.current})`);
+
+        reconnectTimeoutRef.current = setTimeout(() => {
+          connect();
+        }, delay);
+      } else {
+        console.warn('[SessionListUpdates] Max reconnect attempts reached, stopping');
+      }
+    };
+  }, [queryClient]);
+
+  const disconnect = useCallback(() => {
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = undefined;
+    }
+
+    if (eventSourceRef.current) {
+      console.log('[SessionListUpdates] Disconnecting');
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (enabled) {
+      connect();
+    } else {
+      disconnect();
+    }
+
+    return () => {
+      disconnect();
+    };
+  }, [enabled, connect, disconnect]);
+
+  return { disconnect };
+}

--- a/website/client/src/pages/Sessions.tsx
+++ b/website/client/src/pages/Sessions.tsx
@@ -6,6 +6,7 @@ import { useAuthStore, useSessionLastPageStore, useRecentReposStore, type Sessio
 import ChatInput, { type ImageAttachment } from '@/components/ChatInput';
 import type { ChatSession, GitHubRepository } from '@/shared';
 import { truncateSessionName } from '@/lib/utils';
+import { useSessionListUpdates } from '@/hooks/useSessionListUpdates';
 
 // Helper to get the session URL with last visited page
 function getSessionUrl(sessionId: string, getLastPage: (id: string) => string): string {
@@ -66,13 +67,10 @@ export default function Sessions() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['sessions'],
     queryFn: sessionsApi.list,
-    refetchInterval: (query) => {
-      // Poll every 3 seconds if there are any running sessions
-      const sessions = query.state.data?.data?.sessions || [];
-      const hasRunning = sessions.some((s: ChatSession) => s.status === 'running');
-      return hasRunning ? 3000 : false;
-    },
   });
+
+  // Subscribe to real-time session updates via SSE (replaces polling)
+  useSessionListUpdates();
 
   const allSessions: ChatSession[] = data?.data?.sessions || [];
 


### PR DESCRIPTION
## Summary
- Replace 3-second session list polling with Server-Sent Events (SSE) for real-time updates
- Replace notification permission polling with browser Permissions API event listener
- Add new `sessionListBroadcaster` for broadcasting session lifecycle events

## Test plan
- [ ] Open Sessions page and verify SSE connection in Network tab
- [ ] Create a new session and verify it appears without page refresh
- [ ] Complete a session and verify status updates to "completed" without polling
- [ ] Delete a session and verify it disappears from the list immediately
- [ ] Test notification permission detection still works when changing browser settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)