### PR TITLE
Fix Docker COPY instruction that used unsupported shell syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,9 @@ ARG BUILD_COMMIT_SHA
 
 WORKDIR /app/client
 COPY website/client/package*.json ./
-COPY website/client/*.tgz ./ 2>/dev/null || true
+# Copy local tarballs if they exist (using shell to handle missing files gracefully)
+RUN --mount=type=bind,source=website/client,target=/tmp/client \
+    find /tmp/client -maxdepth 1 -name "*.tgz" -exec cp {} ./ \; 2>/dev/null || true
 RUN npm install
 
 COPY website/client/ .


### PR DESCRIPTION
## Summary
- Fix Docker build failure caused by invalid COPY instruction syntax
- The `COPY ... || true` pattern doesn't work in Dockerfiles since COPY doesn't support shell operators
- Replace with `RUN --mount=type=bind` approach that uses `find` to conditionally copy `.tgz` files

## Test plan
- [ ] Verify Docker build succeeds in Dokploy deployment
- [ ] Confirm the website client builds correctly with or without local `.tgz` dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)