### PR TITLE
Add session list broadcast notifications for claude-remote sessions

### DIFF
--- a/internal-api-server/src/routes/executeRemote.ts
+++ b/internal-api-server/src/routes/executeRemote.ts
@@ -15,6 +15,7 @@ import { ensureValidToken, ClaudeAuth } from '../lib/claudeAuth.js';
 import { logger, fetchEnvironmentIdFromSessions } from '@webedt/shared';
 import { CLAUDE_ENVIRONMENT_ID, CLAUDE_API_BASE_URL } from '../config/env.js';
 import { sessionEventBroadcaster } from '../lib/sessionEventBroadcaster.js';
+import { sessionListBroadcaster } from '../lib/sessionListBroadcaster.js';
 import {
   getExecutionProvider,
   type ExecutionEvent,
@@ -274,11 +275,17 @@ const executeRemoteHandler = async (req: Request, res: Response) => {
         baseBranch: baseBranch,
       }).returning();
       chatSession = newSession;
+
+      // Notify subscribers about new session
+      sessionListBroadcaster.notifySessionCreated(user.id, chatSession);
     } else {
       // Update existing session
       await db.update(chatSessions)
         .set({ status: 'running', userRequest: serializedRequest })
         .where(eq(chatSessions.id, chatSessionId));
+
+      // Notify subscribers about status change
+      sessionListBroadcaster.notifyStatusChanged(user.id, { id: chatSessionId, status: 'running' });
     }
 
     // Store user message
@@ -429,9 +436,10 @@ const executeRemoteHandler = async (req: Request, res: Response) => {
       }
 
       // Update session with result
+      const finalStatus = result.status === 'completed' ? 'completed' : 'error';
       await db.update(chatSessions)
         .set({
-          status: result.status === 'completed' ? 'completed' : 'error',
+          status: finalStatus,
           branch: result.branch,
           remoteSessionId: result.remoteSessionId,
           remoteWebUrl: result.remoteWebUrl,
@@ -439,6 +447,16 @@ const executeRemoteHandler = async (req: Request, res: Response) => {
           completedAt: new Date(),
         })
         .where(eq(chatSessions.id, chatSessionId));
+
+      // Notify subscribers about completion
+      sessionListBroadcaster.notifyStatusChanged(user.id, {
+        id: chatSessionId,
+        status: finalStatus,
+        branch: result.branch,
+        remoteSessionId: result.remoteSessionId,
+        remoteWebUrl: result.remoteWebUrl,
+        totalCost: result.totalCost?.toString(),
+      });
 
       logger.info('Execute Remote completed', {
         component: 'ExecuteRemoteRoute',
@@ -477,6 +495,9 @@ const executeRemoteHandler = async (req: Request, res: Response) => {
       await db.update(chatSessions)
         .set({ status: 'error' })
         .where(eq(chatSessions.id, chatSessionId));
+
+      // Notify subscribers about error status
+      sessionListBroadcaster.notifyStatusChanged(user.id, { id: chatSessionId, status: 'error' });
 
       // Send error event
       await sendEvent({

--- a/internal-api-server/src/services/claudeSessionSync.ts
+++ b/internal-api-server/src/services/claudeSessionSync.ts
@@ -10,6 +10,7 @@ import { eq, and, isNotNull, isNull } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { ClaudeRemoteClient, generateSessionPath, logger } from '@webedt/shared';
 import { ensureValidToken } from '../lib/claudeAuth.js';
+import { sessionListBroadcaster } from '../lib/sessionListBroadcaster.js';
 import {
   CLAUDE_ENVIRONMENT_ID,
   CLAUDE_API_BASE_URL,
@@ -158,6 +159,14 @@ async function syncUserSessions(userId: string, claudeAuth: NonNullable<typeof u
             })
             .where(eq(chatSessions.id, runningSession.id));
 
+          // Notify subscribers about status change
+          sessionListBroadcaster.notifyStatusChanged(userId, {
+            id: runningSession.id,
+            status: newStatus,
+            totalCost: totalCost || undefined,
+            branch: branch || undefined,
+          });
+
           result.updated++;
           logger.info(`[SessionSync] Updated session ${runningSession.id} from running to ${newStatus}`, {
             component: 'SessionSync',
@@ -260,7 +269,7 @@ async function syncUserSessions(userId: string, claudeAuth: NonNullable<typeof u
           totalCost = resultEvent.total_cost_usd.toFixed(6);
         }
 
-        await db.insert(chatSessions).values({
+        const [importedSession] = await db.insert(chatSessions).values({
           id: sessionId,
           userId,
           userRequest,
@@ -278,7 +287,10 @@ async function syncUserSessions(userId: string, claudeAuth: NonNullable<typeof u
           completedAt: status === 'completed' || status === 'error'
             ? new Date(remoteSession.updated_at)
             : undefined,
-        });
+        }).returning();
+
+        // Notify subscribers about imported session
+        sessionListBroadcaster.notifySessionCreated(userId, importedSession);
 
         // Import events
         for (const event of sessionEvents) {


### PR DESCRIPTION
## Summary

- Add `sessionListBroadcaster` notifications to `executeRemote.ts` for real-time session list updates
- Add `sessionListBroadcaster` notifications to `claudeSessionSync.ts` for background sync operations
- Fixes duplicate sessions appearing in sidebar with inconsistent states (one "running", one "completed")

## Root Cause

The `executeRemote.ts` route was missing `sessionListBroadcaster` notifications that the frontend uses to update the session list in real-time. This caused:
1. Sessions stuck in "running" state in the UI even after completion
2. Background sync importing duplicate sessions from Anthropic API

## Changes

**executeRemote.ts:**
- `notifySessionCreated()` when a new session is created
- `notifyStatusChanged()` when resuming an existing session
- `notifyStatusChanged()` when session completes or errors

**claudeSessionSync.ts:**
- `notifyStatusChanged()` when sync updates a running session's status
- `notifySessionCreated()` when sync imports a new session

## Test plan

- [ ] Create a new claude-remote session and verify it appears in sidebar immediately
- [ ] Verify session status updates to "completed" in sidebar when execution finishes
- [ ] Verify no duplicate sessions appear after background sync runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)