### PR TITLE
Show full thinking content without expand/collapse

### DIFF
--- a/website/client/src/components/FormattedEvent.tsx
+++ b/website/client/src/components/FormattedEvent.tsx
@@ -236,12 +236,10 @@ export function FormattedEvent({ event, filters = {} }: { event: RawEvent; filte
       <div className="my-1">
         {/* Thinking blocks as status lines with brain emoji */}
         {thinkingBlocks.map((block: any, i: number) => (
-          <div key={`thinking-${i}`} className="py-1 text-xs text-base-content/60 flex items-center gap-2">
-            <span className="font-mono opacity-50">{time}</span>
-            <span>🧠</span>
-            <span className="opacity-70 italic">
-              <ExpandableText text={block.thinking || ''} maxLength={100} />
-            </span>
+          <div key={`thinking-${i}`} className="py-1 text-xs text-base-content/60 flex items-start gap-2">
+            <span className="font-mono opacity-50 shrink-0">{time}</span>
+            <span className="shrink-0">🧠</span>
+            <span className="opacity-70 italic whitespace-pre-wrap">{block.thinking || ''}</span>
           </div>
         ))}
         {/* Main assistant message bubble - blue */}


### PR DESCRIPTION
## Summary
- Remove ExpandableText wrapper from thinking blocks in chat session
- Display complete thinking text with proper line wrapping
- Align timestamp and brain emoji to top when text spans multiple lines

## Test plan
- [ ] Open a chat session with thinking/reasoning content
- [ ] Verify thinking blocks show full text without truncation
- [ ] Verify multi-line thinking content wraps properly
- [ ] Verify timestamp and emoji stay aligned to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)