### PR TITLE
Remove unused ExpandableText import

### DIFF
--- a/website/client/src/components/FormattedEvent.tsx
+++ b/website/client/src/components/FormattedEvent.tsx
@@ -1,4 +1,4 @@
-import { ExpandableText, ExpandableJson } from './ExpandableContent';
+import { ExpandableJson } from './ExpandableContent';
 import { MarkdownRenderer } from './MarkdownRenderer';
 
 // Raw event type for formatted view - now uses type directly instead of eventType wrapper


### PR DESCRIPTION
## Summary
- Remove unused `ExpandableText` import from `FormattedEvent.tsx`
- This import was left behind after `MarkdownRenderer` was added and replaced the usage
- Fixes TypeScript build failure caused by `noUnusedLocals` compiler option

## Test plan
- [x] Verified `npm run build` succeeds in `website/client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)