### PR TITLE
Add truncation with expand option for thinking blocks

### DIFF
--- a/website/client/src/components/ExpandableContent.tsx
+++ b/website/client/src/components/ExpandableContent.tsx
@@ -49,3 +49,35 @@ export function ExpandableJson({ data, summary, defaultOpen = false }: { data: a
     </details>
   );
 }
+
+// Expandable thinking component - shows truncated thinking with expand option
+// Uses details/summary for native collapsible behavior
+export function ExpandableThinking({
+  text,
+  maxLength = 256,
+  className = ''
+}: {
+  text: string;
+  maxLength?: number;
+  className?: string
+}) {
+  const needsTruncate = text.length > maxLength;
+
+  if (!needsTruncate) {
+    return <span className={`opacity-70 italic whitespace-pre-wrap ${className}`}>{text}</span>;
+  }
+
+  const truncatedText = text.substring(0, maxLength);
+
+  return (
+    <details className={`inline ${className}`}>
+      <summary className="cursor-pointer list-none">
+        <span className="opacity-70 italic">{truncatedText}</span>
+        <span className="text-primary hover:underline text-xs ml-1">...</span>
+      </summary>
+      <div className="opacity-70 italic whitespace-pre-wrap mt-1 pl-2 border-l-2 border-base-content/20">
+        {text}
+      </div>
+    </details>
+  );
+}

--- a/website/client/src/components/FormattedEvent.tsx
+++ b/website/client/src/components/FormattedEvent.tsx
@@ -1,4 +1,4 @@
-import { ExpandableJson } from './ExpandableContent';
+import { ExpandableJson, ExpandableThinking } from './ExpandableContent';
 import { MarkdownRenderer } from './MarkdownRenderer';
 
 // Raw event type for formatted view - now uses type directly instead of eventType wrapper
@@ -335,12 +335,12 @@ export function FormattedEvent({ event, filters = {}, toolResultMap }: { event: 
 
     return (
       <div className="my-1">
-        {/* Thinking blocks as status lines with brain emoji */}
+        {/* Thinking blocks as status lines with brain emoji - truncated with expand option */}
         {thinkingBlocks.map((block: any, i: number) => (
           <div key={`thinking-${i}`} className="py-1 text-xs text-base-content/60 flex items-start gap-2">
             <span className="font-mono opacity-50 shrink-0">{time}</span>
             <span className="shrink-0">🧠</span>
-            <span className="opacity-70 italic whitespace-pre-wrap">{block.thinking || ''}</span>
+            <ExpandableThinking text={block.thinking || ''} maxLength={256} />
           </div>
         ))}
         {/* Main assistant message bubble - blue */}


### PR DESCRIPTION
- Create ExpandableThinking component that truncates at 256 characters
- Use native details/summary for collapsible behavior
- Show full thinking content with border indent when expanded