### PR TITLE
Normalize Git Repo Names

### DIFF
--- a/internal-api-server/src/api/routes/execute.ts
+++ b/internal-api-server/src/api/routes/execute.ts
@@ -21,7 +21,7 @@ import { ensureValidGeminiToken, isValidGeminiAuth } from '../../logic/auth/gemi
 import type { GeminiAuth } from '../../logic/auth/lucia.js';
 import { StorageService } from '../../logic/storage/storageService.js';
 import { GitHubOperations, parseRepoUrl } from '../../logic/github/operations.js';
-import { logger, generateSessionPath, getEventEmoji } from '@webedt/shared';
+import { logger, generateSessionPath, getEventEmoji, normalizeRepoUrl } from '@webedt/shared';
 import { WORKSPACE_DIR } from '../../logic/config/env.js';
 import { sessionEventBroadcaster } from '../../logic/sessions/sessionEventBroadcaster.js';
 import { sessionListBroadcaster } from '../../logic/sessions/sessionListBroadcaster.js';
@@ -135,7 +135,8 @@ const executeHandler = async (req: Request, res: Response) => {
       }
     }
 
-    const repoUrl = github?.repoUrl;
+    // Normalize repo URL to prevent duplicates (remove .git suffix)
+    const repoUrl = github?.repoUrl ? normalizeRepoUrl(github.repoUrl) : undefined;
     const branch = github?.branch || 'main';
 
     logger.info('Execute request received', {

--- a/internal-api-server/src/api/routes/executeRemote.ts
+++ b/internal-api-server/src/api/routes/executeRemote.ts
@@ -12,7 +12,7 @@ import { db, chatSessions, messages, users, events } from '../../logic/db/index.
 import { eq } from 'drizzle-orm';
 import { requireAuth, AuthRequest } from '../middleware/auth.js';
 import { ensureValidToken, ClaudeAuth } from '../../logic/auth/claudeAuth.js';
-import { logger, fetchEnvironmentIdFromSessions } from '@webedt/shared';
+import { logger, fetchEnvironmentIdFromSessions, normalizeRepoUrl } from '@webedt/shared';
 import { CLAUDE_ENVIRONMENT_ID, CLAUDE_API_BASE_URL } from '../../logic/config/env.js';
 import { sessionEventBroadcaster } from '../../logic/sessions/sessionEventBroadcaster.js';
 import { sessionListBroadcaster } from '../../logic/sessions/sessionListBroadcaster.js';
@@ -144,7 +144,8 @@ const executeRemoteHandler = async (req: Request, res: Response) => {
       }
     }
 
-    let repoUrl = github?.repoUrl;
+    // Normalize repo URL to prevent duplicates (remove .git suffix)
+    let repoUrl = github?.repoUrl ? normalizeRepoUrl(github.repoUrl) : undefined;
     const baseBranch = github?.branch || 'main'; // Client sends base branch as "branch"
 
     // Extract owner and repo name from URL (for PR functionality)

--- a/internal-api-server/src/logic/sessions/claudeSessionSync.ts
+++ b/internal-api-server/src/logic/sessions/claudeSessionSync.ts
@@ -8,7 +8,7 @@
 import { db, chatSessions, events, users } from '../db/index.js';
 import { eq, and, or, isNotNull, isNull, gte } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
-import { ClaudeRemoteClient, generateSessionPath, logger } from '@webedt/shared';
+import { ClaudeRemoteClient, generateSessionPath, logger, normalizeRepoUrl } from '@webedt/shared';
 import { ensureValidToken } from '../auth/claudeAuth.js';
 import { sessionListBroadcaster } from './sessionListBroadcaster.js';
 import {
@@ -232,7 +232,8 @@ async function syncUserSessions(userId: string, claudeAuth: NonNullable<typeof u
         let branch: string | undefined;
 
         if (gitSource?.url) {
-          repositoryUrl = gitSource.url;
+          // Normalize URL to prevent duplicates (remove .git suffix)
+          repositoryUrl = normalizeRepoUrl(gitSource.url);
           const match = gitSource.url.match(/github\.com\/([^\/]+)\/([^\/]+)/);
           if (match) {
             repositoryOwner = match[1];

--- a/internal-api-server/src/logic/utils/sessionPathHelper.ts
+++ b/internal-api-server/src/logic/utils/sessionPathHelper.ts
@@ -10,6 +10,22 @@
 const SESSION_PATH_SEPARATOR = '__';
 
 /**
+ * Normalize a repository name by removing the .git suffix if present.
+ * This ensures consistent storage and comparison of repository names.
+ */
+export function normalizeRepoName(repoName: string): string {
+  return repoName.replace(/\.git$/, '');
+}
+
+/**
+ * Normalize a GitHub repository URL by removing the .git suffix if present.
+ * This ensures consistent storage and comparison of repository URLs.
+ */
+export function normalizeRepoUrl(repoUrl: string): string {
+  return repoUrl.replace(/\.git$/, '');
+}
+
+/**
  * Parse GitHub repository URL to extract owner and repository name
  * Supports formats:
  * - https://github.com/owner/repo

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -23,6 +23,8 @@ export {
   parseSessionPath,
   sessionPathToDir,
   validateSessionPath,
+  normalizeRepoName,
+  normalizeRepoUrl,
 } from './sessionPathHelper.js';
 
 // Preview URL Helper

--- a/shared/src/sessionPathHelper.ts
+++ b/shared/src/sessionPathHelper.ts
@@ -10,6 +10,22 @@
 const SESSION_PATH_SEPARATOR = '__';
 
 /**
+ * Normalize a repository name by removing the .git suffix if present.
+ * This ensures consistent storage and comparison of repository names.
+ */
+export function normalizeRepoName(repoName: string): string {
+  return repoName.replace(/\.git$/, '');
+}
+
+/**
+ * Normalize a GitHub repository URL by removing the .git suffix if present.
+ * This ensures consistent storage and comparison of repository URLs.
+ */
+export function normalizeRepoUrl(repoUrl: string): string {
+  return repoUrl.replace(/\.git$/, '');
+}
+
+/**
  * Parse GitHub repository URL to extract owner and repository name
  * Supports formats:
  * - https://github.com/owner/repo


### PR DESCRIPTION
- Add normalizeRepoName and normalizeRepoUrl utility functions to shared package
- Update execute route to normalize repo URL on input
- Update executeRemote route to normalize repo URL on input
- Update create-code-session route to normalize both repo name and URL
- Update claudeSessionSync to normalize repo URL when syncing from Claude API
- Ensures consistent storage without .git suffix to prevent duplicate sessions