### PR TITLE
Fix chat session not starting on input

### DIFF
--- a/website/client/src/pages/Chat.tsx
+++ b/website/client/src/pages/Chat.tsx
@@ -1527,6 +1527,30 @@ export default function Chat({ sessionId: sessionIdProp, isEmbedded = false }: C
       // Note: We only set local state here. The sync effect handles clearing workerStore.
       setIsExecuting(false);
       setStreamUrl(null);
+      setIsReconnecting(false);
+
+      // Add error message to rawEvents so user can see what went wrong
+      setRawEvents((prev) => [
+        ...prev,
+        {
+          type: 'error',
+          message: error.message || 'Connection failed',
+          timestamp: new Date(),
+        },
+      ]);
+
+      // Also add as a formatted message
+      messageIdCounter.current += 1;
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now() + messageIdCounter.current,
+          chatSessionId: sessionId && sessionId !== 'new' ? sessionId : '',
+          type: 'system',
+          content: `Error: ${error.message || 'Connection failed'}`,
+          timestamp: new Date(),
+        },
+      ]);
     },
     autoReconnect: false, // Disable auto-reconnect to prevent infinite loops
   });


### PR DESCRIPTION
- Display streaming errors to users instead of silent failures When the SSE stream fails, the error is now shown to the user in both rawEvents and messages, so they can see what went wrong instead of seeing a blank centered input

- Fix duplicate SSE headers bug when reusing existing sessions When an existing active session was found and reused (same repo/branch), the code was sending SSE headers twice - once early in session reuse block and again in the main flow. This would break the stream. Now the session-created event is only sent once in the main flow with a reused flag to indicate if the session was reused.