### PR TITLE
Debug API session authentication endpoint

### DIFF
--- a/internal-api-server/src/api/routes/execute.ts
+++ b/internal-api-server/src/api/routes/execute.ts
@@ -546,11 +546,12 @@ const executeHandler = async (req: Request, res: Response) => {
     sessionListBroadcaster.notifyStatusChanged(user.id, { id: chatSession.id, status: 'running' });
 
     // Setup heartbeat interval (keeps connection alive and signals activity)
+    // Using 15 second interval to prevent proxy timeouts (Traefik default is ~30-60s)
     const heartbeatInterval = setInterval(() => {
       if (!clientDisconnected && !res.writableEnded) {
         res.write(`event: heartbeat\ndata: {}\n\n`);
       }
-    }, 30000); // Send heartbeat every 30 seconds
+    }, 15000);
 
     try {
       // ========================================================================

--- a/internal-api-server/src/api/routes/executeRemote.ts
+++ b/internal-api-server/src/api/routes/executeRemote.ts
@@ -457,7 +457,8 @@ const executeRemoteHandler = async (req: Request, res: Response) => {
       sessionEventBroadcaster.broadcast(chatSessionId, event.type, event);
     };
 
-    // Set up heartbeat
+    // Set up heartbeat - use 15 second interval to prevent proxy timeouts
+    // Traefik and other proxies often have 30-60 second idle timeouts
     const heartbeatInterval = setInterval(() => {
       if (!clientDisconnected) {
         try {
@@ -468,7 +469,7 @@ const executeRemoteHandler = async (req: Request, res: Response) => {
       } else {
         clearInterval(heartbeatInterval);
       }
-    }, 30000);
+    }, 15000);
 
     // Send input preview event immediately so user sees their request was received
     if (userRequest) {

--- a/internal-api-server/src/api/routes/orchestrator.ts
+++ b/internal-api-server/src/api/routes/orchestrator.ts
@@ -232,14 +232,15 @@ router.get('/:id/stream', requireAuth, async (req: Request, res: Response): Prom
       }
     });
 
-    // Heartbeat
+    // Heartbeat - use 15 second interval to prevent proxy timeouts
+    // Many reverse proxies (Traefik, nginx) have default timeouts around 30-60 seconds
     const heartbeat = setInterval(() => {
       if (res.writableEnded) {
         clearInterval(heartbeat);
         return;
       }
       res.write(': heartbeat\n\n');
-    }, 30000);
+    }, 15000);
 
     // Cleanup on disconnect
     req.on('close', () => {

--- a/internal-api-server/src/api/routes/sessions.ts
+++ b/internal-api-server/src/api/routes/sessions.ts
@@ -217,14 +217,15 @@ router.get('/updates', requireAuth, async (req: Request, res: Response) => {
     }
   });
 
-  // Send heartbeat every 30 seconds to keep connection alive
+  // Send heartbeat every 15 seconds to keep connection alive
+  // Reduced from 30s to prevent proxy timeouts (Traefik default is ~30-60s)
   const heartbeatInterval = setInterval(() => {
     if (res.writableEnded) {
       clearInterval(heartbeatInterval);
       return;
     }
     res.write(`:heartbeat\n\n`);
-  }, 30000);
+  }, 15000);
 
   // Handle client disconnect
   req.on('close', () => {


### PR DESCRIPTION
- Reduce heartbeat interval from 30s to 15s in all SSE endpoints to prevent reverse proxy timeouts (Traefik/nginx typically timeout after 30-60 seconds of inactivity)
- Add additional SSE-friendly headers to website proxy:
  - X-Content-Type-Options: nosniff
  - Pragma: no-cache
  - Expires: 0
  - Connection: keep-alive
- Set Accept: text/event-stream header on proxy requests