### PR TITLE
Fix TypeScript type conflicts in Drizzle ORM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10032,7 +10032,6 @@
         "@types/uuid": "^10.0.0",
         "bcrypt": "^5.1.1",
         "drizzle-kit": "^0.31.8",
-        "drizzle-orm": "^0.38.3",
         "lucia": "^3.2.2",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",

--- a/shared/src/db/index.ts
+++ b/shared/src/db/index.ts
@@ -472,3 +472,28 @@ export {
   type ConnectionStats,
   type DatabaseHealthCheckResult,
 } from './connection.js';
+
+// Re-export drizzle-orm operators to prevent duplicate package issues in Docker builds
+// Consumers should import these from @webedt/shared instead of drizzle-orm directly
+export {
+  eq,
+  and,
+  or,
+  not,
+  lt,
+  lte,
+  gt,
+  gte,
+  ne,
+  sql,
+  asc,
+  desc,
+  isNull,
+  isNotNull,
+  inArray,
+  notInArray,
+  like,
+  ilike,
+  between,
+  exists,
+} from 'drizzle-orm';

--- a/website/backend/package.json
+++ b/website/backend/package.json
@@ -42,7 +42,6 @@
     "@types/uuid": "^10.0.0",
     "bcrypt": "^5.1.1",
     "drizzle-kit": "^0.31.8",
-    "drizzle-orm": "^0.38.3",
     "lucia": "^3.2.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/website/backend/src/api/routes/admin.ts
+++ b/website/backend/src/api/routes/admin.ts
@@ -4,10 +4,8 @@
  */
 
 import { Router } from 'express';
-import { db } from '@webedt/shared';
-import { users, sessions } from '@webedt/shared';
+import { db, users, sessions, eq, sql } from '@webedt/shared';
 import { AuthRequest, requireAdmin } from '../middleware/auth.js';
-import { eq, sql } from 'drizzle-orm';
 import { lucia } from '@webedt/shared';
 import bcrypt from 'bcrypt';
 

--- a/website/backend/src/api/routes/auth.ts
+++ b/website/backend/src/api/routes/auth.ts
@@ -6,9 +6,8 @@
 import { Router, Request, Response } from 'express';
 import bcrypt from 'bcrypt';
 import { generateIdFromEntropySize } from 'lucia';
-import { db, users } from '@webedt/shared';
+import { db, users, eq } from '@webedt/shared';
 import { lucia } from '@webedt/shared';
-import { eq } from 'drizzle-orm';
 import type { AuthRequest } from '../middleware/auth.js';
 import { ensureValidToken, ClaudeAuth } from '@webedt/shared';
 import { ensureValidCodexToken, isValidCodexAuth, CodexAuth } from '@webedt/shared';

--- a/website/backend/src/api/routes/executeRemote.ts
+++ b/website/backend/src/api/routes/executeRemote.ts
@@ -8,8 +8,7 @@
 
 import { Router, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { db, chatSessions, messages, users, events } from '@webedt/shared';
-import { eq } from 'drizzle-orm';
+import { db, chatSessions, messages, users, events, eq } from '@webedt/shared';
 import { requireAuth, AuthRequest } from '../middleware/auth.js';
 import { ensureValidToken, ClaudeAuth } from '@webedt/shared';
 import { logger, fetchEnvironmentIdFromSessions, normalizeRepoUrl, generateSessionPath } from '@webedt/shared';

--- a/website/backend/src/api/routes/github.ts
+++ b/website/backend/src/api/routes/github.ts
@@ -5,8 +5,7 @@
 
 import { Router, Request, Response } from 'express';
 import { Octokit } from '@octokit/rest';
-import { db, users, chatSessions, events } from '@webedt/shared';
-import { eq, and, isNull } from 'drizzle-orm';
+import { db, users, chatSessions, events, eq, and, isNull } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
 import { logger, ClaudeRemoteClient } from '@webedt/shared';

--- a/website/backend/src/api/routes/imageGen.ts
+++ b/website/backend/src/api/routes/imageGen.ts
@@ -4,8 +4,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { db, users } from '@webedt/shared';
-import { eq } from 'drizzle-orm';
+import { db, users, eq } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
 

--- a/website/backend/src/api/routes/internalSessions.ts
+++ b/website/backend/src/api/routes/internalSessions.ts
@@ -21,8 +21,7 @@
 
 import { Router, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { db, chatSessions, events, users } from '@webedt/shared';
-import { eq, desc, asc, and, isNull } from 'drizzle-orm';
+import { db, chatSessions, events, users, eq, desc, asc, and, isNull } from '@webedt/shared';
 import { requireAuth, AuthRequest } from '../middleware/auth.js';
 import { ensureValidToken, ClaudeAuth } from '@webedt/shared';
 import {

--- a/website/backend/src/api/routes/liveChat.ts
+++ b/website/backend/src/api/routes/liveChat.ts
@@ -1,8 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and, desc } from 'drizzle-orm';
-import { db } from '@webedt/shared';
-import { liveChatMessages } from '@webedt/shared';
+import { db, liveChatMessages, eq, and, desc } from '@webedt/shared';
 import { requireAuth } from '../middleware/auth.js';
 import { logger } from '@webedt/shared';
 

--- a/website/backend/src/api/routes/resume.ts
+++ b/website/backend/src/api/routes/resume.ts
@@ -11,8 +11,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { db, chatSessions, events } from '@webedt/shared';
-import { eq, and, or, asc } from 'drizzle-orm';
+import { db, chatSessions, events, eq, and, or, asc } from '@webedt/shared';
 import { requireAuth, AuthRequest } from '../middleware/auth.js';
 import { logger } from '@webedt/shared';
 import { sessionEventBroadcaster } from '@webedt/shared';

--- a/website/backend/src/api/routes/sessions.ts
+++ b/website/backend/src/api/routes/sessions.ts
@@ -5,9 +5,8 @@
 
 import { Router, Request, Response } from 'express';
 import { Octokit } from '@octokit/rest';
-import { db, chatSessions, messages, users, events } from '@webedt/shared';
+import { db, chatSessions, messages, users, events, eq, desc, inArray, and, asc, isNull, isNotNull } from '@webedt/shared';
 import type { ChatSession } from '@webedt/shared';
-import { eq, desc, inArray, and, asc, isNull, isNotNull } from 'drizzle-orm';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
 import { getPreviewUrl, logger, generateSessionPath, ClaudeRemoteClient, fetchEnvironmentIdFromSessions } from '@webedt/shared';

--- a/website/backend/src/api/routes/user.ts
+++ b/website/backend/src/api/routes/user.ts
@@ -4,8 +4,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { db, users } from '@webedt/shared';
-import { eq } from 'drizzle-orm';
+import { db, users, eq } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
 import { shouldRefreshClaudeToken, refreshClaudeToken, type ClaudeAuth } from '@webedt/shared';

--- a/website/backend/src/api/routes/workspace.ts
+++ b/website/backend/src/api/routes/workspace.ts
@@ -1,8 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { eq, and, gt, desc } from 'drizzle-orm';
-import { db } from '@webedt/shared';
-import { workspacePresence, workspaceEvents, users } from '@webedt/shared';
+import { db, workspacePresence, workspaceEvents, users, eq, and, gt, desc } from '@webedt/shared';
 import { requireAuth } from '../middleware/auth.js';
 import { logger } from '@webedt/shared';
 

--- a/website/backend/src/index.ts
+++ b/website/backend/src/index.ts
@@ -41,8 +41,7 @@ import liveChatRoutes from './api/routes/liveChat.js';
 import workspaceRoutes from './api/routes/workspace.js';
 
 // Import database for orphan cleanup
-import { db, chatSessions, events, checkHealth as checkDbHealth, getConnectionStats } from '@webedt/shared';
-import { eq, and, lt, sql } from 'drizzle-orm';
+import { db, chatSessions, events, checkHealth as checkDbHealth, getConnectionStats, eq, and, lt, sql } from '@webedt/shared';
 
 // Import middleware
 import { authMiddleware } from './api/middleware/auth.js';


### PR DESCRIPTION
Re-export drizzle-orm operators from the shared package and update all backend imports to use @webedt/shared instead of drizzle-orm directly. This prevents duplicate package installations in Docker that cause TypeScript type incompatibility errors with private properties.