### PR TITLE
Define task status limits and constraints

### DIFF
--- a/tools/auto-task/src/commands/daemon.ts
+++ b/tools/auto-task/src/commands/daemon.ts
@@ -38,8 +38,8 @@ export const daemonCommand = new Command('daemon')
   .action(async (options) => {
     const rootDir = path.resolve(options.root);
     const pollInterval = options.pollInterval || POLL_INTERVAL_MS;
-    const maxReady = options.maxReady || 3;
-    const maxInProgress = options.maxInProgress || 3;
+    const maxReady = options.maxReady || 6;
+    const maxInProgress = options.maxInProgress || 6;
 
     console.log('\nAuto-Task Daemon Starting');
     console.log('='.repeat(60));


### PR DESCRIPTION
Update default limits for Ready and In Progress columns to allow more concurrent task processing in the auto-task daemon.