### PR TITLE
Fix YAML parsing error in diffs route

### DIFF
--- a/website/backend/src/api/routes/diffs.ts
+++ b/website/backend/src/api/routes/diffs.ts
@@ -3,9 +3,6 @@
  * tags:
  *   - name: Diffs
  *     description: File diff operations and comparison between Git branches
- *
- * Diff Routes
- * Provides diff visualization comparing current branch against base branch
  */
 
 import { Router, Request, Response } from 'express';


### PR DESCRIPTION
Remove invalid plain text lines from @openapi JSDoc block that were causing YAMLSemanticError on backend startup. The OpenAPI parser requires valid YAML syntax inside @openapi blocks.