### PR TITLE
Set up health monitoring and trash cleanup services

### DIFF
--- a/website/backend/src/index.ts
+++ b/website/backend/src/index.ts
@@ -107,8 +107,12 @@ async function cleanupOrphanedSessions(): Promise<{ success: boolean; cleaned: n
     const timeoutThreshold = new Date(Date.now() - ORPHAN_SESSION_TIMEOUT_MINUTES * 60 * 1000);
 
     // Find sessions stuck in 'running' or 'pending' for too long
+    // Only select the columns we need to avoid failures if DB schema is out of sync
     const stuckSessions = await db
-      .select()
+      .select({
+        id: chatSessions.id,
+        status: chatSessions.status,
+      })
       .from(chatSessions)
       .where(
         and(


### PR DESCRIPTION
The orphan cleanup query was using .select() without specifying columns, which selected ALL columns from the chatSessions table. This caused failures when the database schema didn't have all columns defined in the TypeScript schema (like favorite, shareToken, shareExpiresAt).

Now the query only selects the id and status columns, which are the only columns actually used by the cleanup logic.