### PR TITLE
Initialize PostgreSQL database connection

### DIFF
--- a/shared/src/db/index.ts
+++ b/shared/src/db/index.ts
@@ -259,6 +259,10 @@ async function doInitialize(): Promise<void> {
       }
     }
 
+    if (schemaUpdate.duplicatesRemoved > 0) {
+      console.log(`  Cleaned up duplicate events: ${schemaUpdate.duplicatesRemoved} removed`);
+    }
+
     if (schemaUpdate.indexesCreated.length > 0) {
       console.log('  Created indexes:');
       for (const idx of schemaUpdate.indexesCreated) {
@@ -273,7 +277,7 @@ async function doInitialize(): Promise<void> {
       }
     }
 
-    if (schemaUpdate.columnsAdded.length === 0 && schemaUpdate.columnsRemoved.length === 0 && schemaUpdate.errors.length === 0) {
+    if (schemaUpdate.columnsAdded.length === 0 && schemaUpdate.columnsRemoved.length === 0 && schemaUpdate.errors.length === 0 && schemaUpdate.duplicatesRemoved === 0) {
       console.log('  ✅ Schema is up to date');
     }
 


### PR DESCRIPTION
Before creating the unique index idx_events_session_uuid, the migration now checks for and removes duplicate events that share the same (chat_session_id, uuid) combination. This fixes the "could not create unique index" error that occurred when existing data had duplicates.

The deduplication keeps the first event (by id) for each duplicate set.