### PR TITLE
Add Rate Limiting to Unprotected Sensitive Routes:: Protect 15+ endpoints lacking request throttling

### DIFF
--- a/website/backend/src/api/routes/announcements.ts
+++ b/website/backend/src/api/routes/announcements.ts
@@ -18,6 +18,7 @@ import {
 } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAdmin } from '../middleware/auth.js';
+import { publicShareRateLimiter, standardRateLimiter } from '../middleware/rateLimit.js';
 import { logger } from '@webedt/shared';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -138,7 +139,8 @@ const MAX_CONTENT_LENGTH = 50000;
  *         $ref: '#/components/responses/InternalError'
  */
 // Get published announcements (public)
-router.get('/', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const { type, priority, pinned } = req.query;
     const limit = Math.min(parseInt(req.query.limit as string) || 20, 100);
@@ -283,7 +285,8 @@ router.get('/', async (req: Request, res: Response) => {
  */
 // IMPORTANT: Admin routes must be defined BEFORE /:id to avoid route conflicts
 // List all announcements for admin (including drafts and archived)
-router.get('/admin/all', requireAdmin, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.get('/admin/all', standardRateLimiter, requireAdmin, async (req: Request, res: Response) => {
   try {
     const { type, priority, status } = req.query;
     const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
@@ -405,7 +408,8 @@ router.get('/admin/all', requireAdmin, async (req: Request, res: Response) => {
  *         $ref: '#/components/responses/InternalError'
  */
 // Get single announcement (public for published, admin for all)
-router.get('/:id', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/:id', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const announcementId = req.params.id;
     const authReq = req as AuthRequest;
@@ -527,7 +531,8 @@ router.get('/:id', async (req: Request, res: Response) => {
  *         $ref: '#/components/responses/InternalError'
  */
 // Create announcement (admin only)
-router.post('/', requireAdmin, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.post('/', standardRateLimiter, requireAdmin, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const { title, content, type, priority, status, pinned, expiresAt } = req.body;
@@ -691,7 +696,8 @@ router.post('/', requireAdmin, async (req: Request, res: Response) => {
  *         $ref: '#/components/responses/InternalError'
  */
 // Update announcement (admin only)
-router.patch('/:id', requireAdmin, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.patch('/:id', standardRateLimiter, requireAdmin, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const announcementId = req.params.id;
@@ -826,7 +832,8 @@ router.patch('/:id', requireAdmin, async (req: Request, res: Response) => {
  *         $ref: '#/components/responses/InternalError'
  */
 // Delete announcement (admin only)
-router.delete('/:id', requireAdmin, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.delete('/:id', standardRateLimiter, requireAdmin, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const announcementId = req.params.id;

--- a/website/backend/src/api/routes/autocomplete.ts
+++ b/website/backend/src/api/routes/autocomplete.ts
@@ -5,11 +5,16 @@
 
 import { Router, Request, Response } from 'express';
 import { requireAuth } from '../middleware/auth.js';
+import { searchRateLimiter } from '../middleware/rateLimit.js';
 import { AutocompleteService } from '@webedt/shared';
 
 import type { AutocompleteRequest } from '@webedt/shared';
 
 const router = Router();
+
+// Apply rate limiting to all autocomplete routes
+// Rate limit: 30 requests/minute (searchRateLimiter - for search/autocomplete operations)
+router.use(searchRateLimiter);
 
 /**
  * @openapi

--- a/website/backend/src/api/routes/cloudSaves.ts
+++ b/website/backend/src/api/routes/cloudSaves.ts
@@ -7,6 +7,7 @@ import { Router, Request, Response } from 'express';
 import { CloudSavesService, logger } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
+import { fileOperationRateLimiter } from '../middleware/rateLimit.js';
 
 const router = Router();
 
@@ -17,8 +18,10 @@ const router = Router();
  *     description: Game save synchronization across devices
  */
 
-// All routes require authentication
+// All routes require authentication and rate limiting
+// Rate limit: 100 requests/minute (fileOperationRateLimiter - for file sync operations)
 router.use(requireAuth);
+router.use(fileOperationRateLimiter);
 
 /**
  * @openapi

--- a/website/backend/src/api/routes/collections.ts
+++ b/website/backend/src/api/routes/collections.ts
@@ -23,10 +23,15 @@ import {
 } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
+import { standardRateLimiter } from '../middleware/rateLimit.js';
 import type { TransactionContext } from '@webedt/shared';
 import { v4 as uuidv4 } from 'uuid';
 
 const router = Router();
+
+// Apply rate limiting to all collection routes
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.use(standardRateLimiter);
 
 /**
  * @openapi

--- a/website/backend/src/api/routes/community.ts
+++ b/website/backend/src/api/routes/community.ts
@@ -29,6 +29,7 @@ import {
 } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
+import { publicShareRateLimiter, standardRateLimiter } from '../middleware/rateLimit.js';
 import { logger } from '@webedt/shared';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -115,7 +116,8 @@ const router = Router();
  *         $ref: '#/components/responses/InternalError'
  */
 // Get community posts (public)
-router.get('/posts', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/posts', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const { type, gameId, sort = 'createdAt', order = 'desc' } = req.query;
     const { limit, offset } = getPaginationParams({
@@ -202,7 +204,8 @@ router.get('/posts', async (req: Request, res: Response) => {
  *         $ref: '#/components/responses/InternalError'
  */
 // Get single post with comments
-router.get('/posts/:id', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/posts/:id', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const postId = req.params.id;
 
@@ -302,7 +305,8 @@ router.get('/posts/:id', async (req: Request, res: Response) => {
  *         $ref: '#/components/responses/InternalError'
  */
 // Create a post (requires auth)
-router.post('/posts', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.post('/posts', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const { type, title, content, gameId, rating, images } = req.body;
@@ -464,7 +468,8 @@ router.post('/posts', requireAuth, async (req: Request, res: Response) => {
  *         $ref: '#/components/responses/InternalError'
  */
 // Update a post
-router.patch('/posts/:id', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.patch('/posts/:id', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const postId = req.params.id;
@@ -551,7 +556,8 @@ router.patch('/posts/:id', requireAuth, async (req: Request, res: Response) => {
  *         $ref: '#/components/responses/InternalError'
  */
 // Delete a post
-router.delete('/posts/:id', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.delete('/posts/:id', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const postId = req.params.id;
@@ -646,7 +652,8 @@ router.delete('/posts/:id', requireAuth, async (req: Request, res: Response) => 
  *         $ref: '#/components/responses/InternalError'
  */
 // Add a comment
-router.post('/posts/:id/comments', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.post('/posts/:id/comments', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const postId = req.params.id;
@@ -763,7 +770,8 @@ router.post('/posts/:id/comments', requireAuth, async (req: Request, res: Respon
  *         $ref: '#/components/responses/InternalError'
  */
 // Delete a comment
-router.delete('/comments/:id', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.delete('/comments/:id', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const commentId = req.params.id;
@@ -874,7 +882,8 @@ router.delete('/comments/:id', requireAuth, async (req: Request, res: Response) 
  *         $ref: '#/components/responses/InternalError'
  */
 // Vote on a post
-router.post('/posts/:id/vote', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.post('/posts/:id/vote', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const postId = req.params.id;
@@ -1030,7 +1039,8 @@ router.post('/posts/:id/vote', requireAuth, async (req: Request, res: Response) 
  *         $ref: '#/components/responses/InternalError'
  */
 // Vote on a comment
-router.post('/comments/:id/vote', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.post('/comments/:id/vote', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const commentId = req.params.id;
@@ -1172,7 +1182,8 @@ router.post('/comments/:id/vote', requireAuth, async (req: Request, res: Respons
  *         $ref: '#/components/responses/InternalError'
  */
 // Get user's posts
-router.get('/users/:userId/posts', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/users/:userId/posts', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const userId = req.params.userId;
     const { limit, offset } = getPaginationParams({
@@ -1266,7 +1277,8 @@ router.get('/users/:userId/posts', async (req: Request, res: Response) => {
  *         $ref: '#/components/responses/InternalError'
  */
 // Get reviews for a game
-router.get('/games/:gameId/reviews', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/games/:gameId/reviews', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const gameId = req.params.gameId;
     const { limit, offset } = getPaginationParams({

--- a/website/backend/src/api/routes/diffs.ts
+++ b/website/backend/src/api/routes/diffs.ts
@@ -9,11 +9,16 @@ import { Router, Request, Response } from 'express';
 import { Octokit } from '@octokit/rest';
 import { requireAuth } from '../middleware/auth.js';
 import { validatePathParam } from '../middleware/pathValidation.js';
+import { standardRateLimiter } from '../middleware/rateLimit.js';
 import { logger, parseDiff } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import type { ParsedDiff } from '@webedt/shared';
 
 const router = Router();
+
+// Apply rate limiting to all diff routes
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.use(standardRateLimiter);
 
 interface CompareResult {
   diff: ParsedDiff;

--- a/website/backend/src/api/routes/import.ts
+++ b/website/backend/src/api/routes/import.ts
@@ -14,8 +14,13 @@ import fs from 'fs/promises';
 import { fetchFromUrl, validateUrl, WORKSPACE_DIR, db, chatSessions, eq, and } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
+import { fileOperationRateLimiter } from '../middleware/rateLimit.js';
 
 const router = Router();
+
+// Apply rate limiting to all import routes
+// Rate limit: 100 requests/minute (fileOperationRateLimiter - for file import operations)
+router.use(fileOperationRateLimiter);
 
 /**
  * Verify that the user has access to the specified session path

--- a/website/backend/src/api/routes/library.ts
+++ b/website/backend/src/api/routes/library.ts
@@ -38,12 +38,15 @@ import { Router, Request, Response } from 'express';
 import { db, games, userLibrary, purchases, eq, and, desc } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
+import { standardRateLimiter } from '../middleware/rateLimit.js';
 import { logger } from '@webedt/shared';
 
 const router = Router();
 
-// All routes require authentication
+// All routes require authentication and rate limiting
+// Rate limit: 100 requests/minute (standardRateLimiter)
 router.use(requireAuth);
+router.use(standardRateLimiter);
 
 /**
  * @openapi

--- a/website/backend/src/api/routes/purchases.ts
+++ b/website/backend/src/api/routes/purchases.ts
@@ -14,6 +14,7 @@ import { Router, Request, Response } from 'express';
 import { db, games, userLibrary, purchases, wishlists, eq, and, desc, getPaymentService, FRONTEND_URL, FRONTEND_PORT } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
+import { standardRateLimiter, paymentRateLimiter } from '../middleware/rateLimit.js';
 import { logger } from '@webedt/shared';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -62,7 +63,8 @@ router.use(requireAuth);
  *       500:
  *         $ref: '#/components/responses/InternalError'
  */
-router.get('/stats/summary', async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.get('/stats/summary', standardRateLimiter, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
 
@@ -152,7 +154,8 @@ router.get('/stats/summary', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/InternalError'
  */
-router.get('/history', async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.get('/history', standardRateLimiter, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
 
@@ -292,7 +295,8 @@ router.get('/history', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/InternalError'
  */
-router.post('/buy/:gameId', async (req: Request, res: Response) => {
+// Rate limit: 10 requests/minute (paymentRateLimiter - payment operations are sensitive)
+router.post('/buy/:gameId', paymentRateLimiter, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const gameId = req.params.gameId;
@@ -494,7 +498,8 @@ router.post('/buy/:gameId', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/InternalError'
  */
-router.get('/:purchaseId', async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.get('/:purchaseId', standardRateLimiter, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const purchaseId = req.params.purchaseId;
@@ -585,7 +590,8 @@ router.get('/:purchaseId', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/InternalError'
  */
-router.post('/:purchaseId/refund', async (req: Request, res: Response) => {
+// Rate limit: 10 requests/minute (paymentRateLimiter - refund operations are sensitive)
+router.post('/:purchaseId/refund', paymentRateLimiter, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const purchaseId = req.params.purchaseId;

--- a/website/backend/src/api/routes/store.ts
+++ b/website/backend/src/api/routes/store.ts
@@ -71,6 +71,7 @@ import {
 } from '@webedt/shared';
 import type { AuthRequest } from '../middleware/auth.js';
 import { requireAuth } from '../middleware/auth.js';
+import { publicShareRateLimiter, standardRateLimiter } from '../middleware/rateLimit.js';
 import { logger } from '@webedt/shared';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -109,7 +110,8 @@ const router = Router();
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.get('/featured', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/featured', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const limit = Math.min(parseInt(req.query.limit as string) || 10, 50);
 
@@ -156,7 +158,8 @@ router.get('/featured', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.get('/new', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/new', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const limit = Math.min(parseInt(req.query.limit as string) || 10, 50);
     const daysBack = Math.min(parseInt(req.query.days as string) || 30, 90);
@@ -225,7 +228,8 @@ router.get('/new', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.get('/highlights', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/highlights', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const featuredLimit = Math.min(parseInt(req.query.featuredLimit as string) || 6, 20);
     const newLimit = Math.min(parseInt(req.query.newLimit as string) || 6, 20);
@@ -343,7 +347,8 @@ router.get('/highlights', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.get('/browse', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/browse', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const {
       q: query,
@@ -480,7 +485,8 @@ router.get('/browse', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.get('/games/:id', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/games/:id', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const gameId = req.params.id;
 
@@ -545,7 +551,8 @@ router.get('/games/:id', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.get('/games/:id/owned', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.get('/games/:id/owned', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const gameId = req.params.id;
@@ -592,7 +599,8 @@ router.get('/games/:id/owned', requireAuth, async (req: Request, res: Response) 
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.get('/genres', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/genres', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const allGames = await db
       .select({ genres: games.genres })
@@ -647,7 +655,8 @@ router.get('/genres', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.get('/tags', async (req: Request, res: Response) => {
+// Rate limit: 30 requests/minute (publicShareRateLimiter)
+router.get('/tags', publicShareRateLimiter, async (req: Request, res: Response) => {
   try {
     const allGames = await db
       .select({ tags: games.tags })
@@ -714,7 +723,8 @@ router.get('/tags', async (req: Request, res: Response) => {
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.post('/wishlist/:gameId', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.post('/wishlist/:gameId', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const gameId = req.params.gameId;
@@ -797,7 +807,8 @@ router.post('/wishlist/:gameId', requireAuth, async (req: Request, res: Response
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.delete('/wishlist/:gameId', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.delete('/wishlist/:gameId', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const gameId = req.params.gameId;
@@ -853,7 +864,8 @@ router.delete('/wishlist/:gameId', requireAuth, async (req: Request, res: Respon
  *       500:
  *         $ref: '#/components/responses/ServerError'
  */
-router.get('/wishlist', requireAuth, async (req: Request, res: Response) => {
+// Rate limit: 100 requests/minute (standardRateLimiter)
+router.get('/wishlist', standardRateLimiter, requireAuth, async (req: Request, res: Response) => {
   try {
     const authReq = req as AuthRequest;
     const pagination = parseOffsetPagination(req.query as Record<string, unknown>);


### PR DESCRIPTION
## Summary
Automated implementation for issue #1285.

Closes #1285

---
*Created by auto-task daemon*